### PR TITLE
collect-llm: Add Gemini 3.1 Pro, Qwen2.5-72B, and DeepSeek-V4-Pro

### DIFF
--- a/src/data/journal/2026-04-24-collect-llm.md
+++ b/src/data/journal/2026-04-24-collect-llm.md
@@ -1,0 +1,36 @@
+---
+title: "LLM 모델 수집 및 보강 (2026-04-24)"
+date: 2026-04-24
+status: in-progress
+---
+
+## 작업 개요
+- LLM 도메인 신규 모델 발견 및 기존 모델 메타데이터 보강.
+
+## 발견한 신규 모델
+1. **Gemini 3.1 Pro** (Google)
+   - 출시일: 2026-04-22
+   - Context Window: 2,000,000 tokens
+   - 가격: Input $2.00 / Output $12.00 (per 1M tokens)
+   - 출처: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
+2. **Qwen2.5-72B** (Alibaba Cloud)
+   - 출시일: 2024-09-19
+   - Parameter Size: 72B
+   - Context Window: 128,000 tokens
+   - 출처: https://qwenlm.github.io/blog/qwen2.5/
+3. **DeepSeek-V4-Pro** (DeepSeek)
+   - 출시일: 2026-04-24
+   - Context Window: 1,000,000 tokens
+   - 가격: Input $1.74 / Output $3.48 (per 1M tokens)
+   - 출처: https://api-docs.deepseek.com/quick_start/pricing
+
+## 보강한 기존 모델
+1. **DeepSeek-V3**
+   - 가격 보강: Input $0.14 / Output $0.28 (per 1M tokens)
+   - 출처: https://api-docs.deepseek.com/quick_start/pricing
+2. **Solar Pro 3**
+   - Context Window 보강: 32,000 tokens
+   - 출처: https://www.upstage.ai/blog/en/solar-pro-3-0127
+
+## 작업 로그
+- 2026-04-24: 작업 시작. 기존 모델 목록 확인 및 신규 모델(Gemini 3.1 Pro, Qwen2.5-72B, DeepSeek-V4-Pro) 조사 완료.

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -61,7 +61,7 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": null,
+      "contextWindow": 32000,
       "pricing": null,
       "links": {
         "official": "https://www.upstage.ai/blog/en/solar-pro-3-0127"
@@ -88,7 +88,10 @@
     {
       "parameterSize": null,
       "contextWindow": 128000,
-      "pricing": null,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28
+      },
       "links": {
         "official": "https://github.com/deepseek-ai/DeepSeek-V3"
       },
@@ -96,6 +99,51 @@
       "name": "DeepSeek-V3",
       "provider": "DeepSeek",
       "releaseDate": "2024-12-26",
+      "license": "DeepSeek Model License"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 2000000,
+      "pricing": {
+        "input": 2,
+        "output": 12
+      },
+      "links": {
+        "official": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview"
+      },
+      "id": "gemini-3.1-pro",
+      "name": "Gemini 3.1 Pro",
+      "provider": "Google",
+      "releaseDate": "2026-04-22",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": "72B",
+      "contextWindow": 128000,
+      "pricing": null,
+      "links": {
+        "official": "https://qwenlm.github.io/blog/qwen2.5/"
+      },
+      "id": "qwen-2.5-72b",
+      "name": "Qwen2.5-72B",
+      "provider": "Alibaba Cloud",
+      "releaseDate": "2024-09-19",
+      "license": "Qwen Research License"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 1000000,
+      "pricing": {
+        "input": 1.74,
+        "output": 3.48
+      },
+      "links": {
+        "official": "https://api-docs.deepseek.com/quick_start/pricing"
+      },
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek-V4-Pro",
+      "provider": "DeepSeek",
+      "releaseDate": "2026-04-24",
       "license": "DeepSeek Model License"
     }
   ]


### PR DESCRIPTION
Discovered and added three new LLM models with official metadata from April 2026 sources. Supplemented pricing and context window data for existing models (DeepSeek-V3, Solar Pro 3). Updated the task journal with detailed sources and findings. All changes were validated via the local build process and verified using the model management CLI and frontend screenshot analysis.

Fixes #12

---
*PR created automatically by Jules for task [167029120389173104](https://jules.google.com/task/167029120389173104) started by @GGJJack*