### PR TITLE
collect-llm 2026-04-26: New models from Anthropic and Sakana AI

### DIFF
--- a/src/data/journal/2026-04-26-collect-llm.md
+++ b/src/data/journal/2026-04-26-collect-llm.md
@@ -1,0 +1,31 @@
+---
+date: 2026-04-26
+agent: collect-llm
+status: completed
+summary: "Anthropic Claude Opus 4.7 및 Sakana AI 신규 모델(Fugu, Marlin) 수집, Mistral Voxtral TTS 교차 발견"
+---
+
+## Todo
+- [x] 신규 모델 발견 및 등록 (3건: claude-opus-4-7, sakana-fugu-ultra, sakana-marlin)
+- [x] 기존 모델 메타데이터 보강 (1건: claude-4-sonnet 링크)
+- [x] 교차 발견 모델 등록 (1건: voxtral-tts)
+
+## 조사 내역
+- 01:10 기존 모델 목록 확인 완료 (10개)
+- 01:11 Anthropic 뉴스룸 확인: Claude Opus 4.7 (2026-04-16) 발견 ← https://www.anthropic.com/news/claude-opus-4-7
+- 01:12 Sakana AI 블로그 확인: Sakana Fugu (2026-04-24) 및 Sakana Marlin (2026-04-02) 발견 ← https://sakana.ai/blog/
+- 01:13 Mistral AI 뉴스 확인: Voxtral TTS (2026-03-23) 발견 ← https://mistral.ai/news/voxtral-tts
+
+## 수행한 작업
+- 01:25 claude-opus-4-7 등록 (입력 $5, 출력 $25) ← https://www.anthropic.com/news/claude-opus-4-7
+- 01:26 sakana-fugu-ultra 등록 ← https://sakana.ai/fugu-beta/
+- 01:27 sakana-marlin 등록 ← https://sakana.ai/marlin-beta/
+- 01:28 claude-4-sonnet 공식 링크 상세화 ← https://www.anthropic.com/claude/sonnet
+- 01:29 voxtral-tts 교차 발견 등록 (tts 도메인) ← https://mistral.ai/news/voxtral-tts
+
+## 판단 / 고민
+- Sakana Fugu는 Mini와 Ultra 두 버전이 있으나, 고성능 모델인 Ultra를 우선 등록함.
+- Voxtral TTS는 LLM 수집 중 발견되었으므로 AGENTS.md §8 규칙에 따라 교차 발견으로 처리함.
+
+## 이슈 제기
+- (없음)

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -30,7 +30,7 @@
         "output": 15
       },
       "links": {
-        "official": "https://anthropic.com"
+        "official": "https://www.anthropic.com/claude/sonnet"
       }
     },
     {
@@ -145,6 +145,48 @@
       "provider": "DeepSeek",
       "releaseDate": "2026-04-24",
       "license": "DeepSeek Model License"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": {
+        "input": 5,
+        "output": 25
+      },
+      "links": {
+        "official": "https://www.anthropic.com/news/claude-opus-4-7"
+      },
+      "id": "claude-opus-4-7",
+      "name": "Claude Opus 4.7",
+      "provider": "Anthropic",
+      "releaseDate": "2026-04-16",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://sakana.ai/fugu-beta/"
+      },
+      "id": "sakana-fugu-ultra",
+      "name": "Sakana Fugu Ultra",
+      "provider": "Sakana AI",
+      "releaseDate": "2026-04-24",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://sakana.ai/marlin-beta/"
+      },
+      "id": "sakana-marlin",
+      "name": "Sakana Marlin",
+      "provider": "Sakana AI",
+      "releaseDate": "2026-04-02",
+      "license": "Proprietary"
     }
   ]
 }

--- a/src/data/models/tts.json
+++ b/src/data/models/tts.json
@@ -7,12 +7,45 @@
       "provider": "OpenAI",
       "releaseDate": "2023-11-06",
       "license": "Proprietary",
-      "supportedLanguages": ["en", "ko", "ja", "zh", "es", "fr", "de"],
+      "supportedLanguages": [
+        "en",
+        "ko",
+        "ja",
+        "zh",
+        "es",
+        "fr",
+        "de"
+      ],
       "realtime": false,
-      "pricing": { "perCharacter": 0.00003 },
+      "pricing": {
+        "perCharacter": 0.00003
+      },
       "links": {
         "official": "https://platform.openai.com/docs/guides/text-to-speech"
       }
+    },
+    {
+      "supportedLanguages": [
+        "English",
+        "French",
+        "German",
+        "Spanish",
+        "Dutch",
+        "Portuguese",
+        "Italian",
+        "Hindi",
+        "Arabic"
+      ],
+      "realtime": false,
+      "pricing": null,
+      "links": {
+        "official": "https://mistral.ai/news/voxtral-tts"
+      },
+      "id": "voxtral-tts",
+      "name": "Voxtral TTS",
+      "provider": "Mistral AI",
+      "releaseDate": "2026-03-23",
+      "license": "CC BY NC 4.0"
     }
   ]
 }


### PR DESCRIPTION
I have completed the `collect-llm` task for April 26, 2026.

Key changes:
- **New Models Registered (LLM)**:
    - `claude-opus-4-7`: Anthropic's latest model, including pricing ($5/$25).
    - `sakana-fugu-ultra`: Sakana AI's multi-agent orchestration system.
    - `sakana-marlin`: Sakana AI's deep research assistant.
- **Cross-Discovery (TTS)**:
    - `voxtral-tts`: Registered Mistral's new TTS model with supported languages.
- **Maintenance**:
    - Updated `claude-4-sonnet` with a more specific official link.
- **Documentation**:
    - Created `src/data/journal/2026-04-26-collect-llm.md` to record the work.

Verified changes by running the local Astro build and inspecting the leaderboard counts via Playwright screenshots. Cleaned up development artifacts (dev_server.log) before submission.

Fixes #19

---
*PR created automatically by Jules for task [4199740711779087500](https://jules.google.com/task/4199740711779087500) started by @GGJJack*