### PR TITLE
Add detailed benchmark pages for GSM8K and KMMLU

### DIFF
--- a/src/content/benchmarks/gsm8k.md
+++ b/src/content/benchmarks/gsm8k.md
@@ -1,0 +1,20 @@
+---
+benchmarkId: gsm8k
+domain: llm
+status: published
+updated: 2026-04-28
+sources:
+  - https://arxiv.org/abs/2110.14168
+organization: openai
+paperUrl: https://arxiv.org/abs/2110.14168
+highlights:
+  - "8,500개 초등학교 수준 수학 문제 풀이 정확도 평가"
+---
+
+# GSM8K
+
+## 개요
+GSM8K는 초등학교 수준의 수학 문제들을 평가하기 위한 벤치마크이다. 주로 수치적 논리와 다단계 계산이 필요한 문제들로 구성된다.
+
+## 평가 방법
+총 8,500개의 영어 수학 문제를 기반으로 하며, 모델이 도출한 최종 답변의 정확도를 % 단위로 평가한다. 더 높은 점수일수록 높은 성능을 나타낸다. (출처: https://arxiv.org/abs/2110.14168)

--- a/src/content/benchmarks/kmmlu.md
+++ b/src/content/benchmarks/kmmlu.md
@@ -1,0 +1,20 @@
+---
+benchmarkId: kmmlu
+domain: llm
+status: published
+updated: 2026-04-28
+sources:
+  - https://arxiv.org/abs/2402.11548
+paperUrl: https://arxiv.org/abs/2402.11548
+highlights:
+  - "한국어 전문 지식 평가 (45개 분야)"
+  - "35,030개의 전문가 수준 사지선다형 질문 포함"
+---
+
+# KMMLU
+
+## 개요
+KMMLU(Korean Massive Multitask Language Understanding)는 인문학부터 STEM까지 45개 주제에 걸친 한국어 전문 지식을 평가하기 위한 벤치마크이다. 영어를 번역한 기존 데이터셋과 달리 실제 한국어 시험에서 수집되었다.
+
+## 평가 방법
+총 35,030개의 사지선다형 객관식 문제로 구성되어 있으며, 정확도를 % 단위로 평가한다. (출처: https://arxiv.org/abs/2402.11548)

--- a/src/data/journal/2026-04-28-profile-benchmark.md
+++ b/src/data/journal/2026-04-28-profile-benchmark.md
@@ -1,0 +1,12 @@
+---
+date: 2026-04-28
+agent: profile-benchmark
+status: completed
+summary: "gsm8k 및 kmmlu 벤치마크 상세 페이지 작성"
+---
+## Todo
+- [x] gsm8k 벤치마크 상세 페이지 작성
+- [x] kmmlu 벤치마크 상세 페이지 작성
+## 조사 내역
+- 00:00 [x] GSM8K 상세 페이지 작성 완료 ← https://arxiv.org/abs/2110.14168
+- 00:00 [x] KMMLU 상세 페이지 작성 완료 ← https://arxiv.org/abs/2402.11548


### PR DESCRIPTION
This pull request creates the detailed markdown pages for the GSM8K and KMMLU benchmarks. The frontmatter respects the `content.config.ts` validations. The content summarizes the respective papers in Korean as per the skill definition. The journal has also been recorded under `src/data/journal/2026-04-28-profile-benchmark.md`.

---
*PR created automatically by Jules for task [9773770027644757634](https://jules.google.com/task/9773770027644757634) started by @GGJJack*