### PR TITLE
Profile Mistral Medium 3.5 and Sakana Marlin

### DIFF
--- a/src/content/models/mistral-medium-3-5.md
+++ b/src/content/models/mistral-medium-3-5.md
@@ -1,0 +1,33 @@
+---
+modelId: mistral-medium-3-5
+domain: llm
+status: published
+updated: 2026-04-29
+sources:
+  - https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04
+  - https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
+  - https://build.nvidia.com/mistralai/mistral-medium-3.5-128b
+features:
+  toolUse: true
+  vision: true
+  fineTuning: true
+highlights:
+  - "128B Dense 아키텍처"
+  - "256k 컨텍스트 윈도우 지원"
+  - "SWE-bench Verified 77.6% 달성"
+relatedOrganization: mistral-ai
+---
+
+# Mistral Medium 3.5 소개
+
+## 개요
+Mistral Medium 3.5는 2026년 4월 29일에 공개된 Mistral AI의 차세대 플래그십 모델로, 지시 이행(Instruction-following), 추론, 코딩 능력을 하나의 128B 밀집(Dense) 모델로 통합한 것이 특징입니다. 이 모델은 특히 에이전트 환경과 복잡한 코딩 작업에 최적화되어 있으며, Mistral Vibe와 Le Chat의 기본 모델로 채택되었습니다. 공개 가중치(Open Weights) 방식으로 제공되며 수정된 MIT 라이선스(Modified MIT License)를 따릅니다.
+
+## 기술 특징
+Mistral Medium 3.5는 128B 파라미터의 밀집형 아키텍처를 채택하여 실세계 문제 해결 능력을 극대화했습니다. 256k의 광범위한 컨텍스트 윈도우를 제공하며, 요청별로 추론 노력(Reasoning effort)을 설정할 수 있어 간단한 채팅부터 복잡한 에이전트 실행까지 유연하게 대응합니다. 또한, 다양한 이미지 크기와 종횡비를 처리할 수 있도록 처음부터 훈련된 비전 인코더를 탑재하고 있습니다. 벤치마크 결과, SWE-bench Verified에서 77.6%를 기록하며 Devstral 2 및 Qwen3.5 397B 등의 모델을 상회하는 성능을 보여주었습니다.
+
+## 사용 사례
+이 모델은 장기적인 작업(Long-horizon tasks)과 다중 도구 호출(Multiple tool calls)에 강력한 성능을 발휘합니다. 주요 사용 사례로는 Mistral Vibe를 통한 비동기 클라우드 코딩 에이전트, Le Chat의 새로운 '워크 모드(Work mode)'를 통한 연구, 분석 및 도구 간 협업 작업 등이 있습니다. 또한 구조화된 출력(Structured output) 생성이 탁월하여 하위 코드 시스템과의 연동이 용이합니다.
+
+## 한계
+Mistral AI는 해당 모델이 에이전트 및 코딩 워크플로우에 최적화되어 있으나, 특정 매우 전문적인 영역에서의 성능 제한이나 도구 호출 과정에서의 안전 승인 필요성 등을 언급하고 있습니다. 자가 호스팅을 위해서는 최소 4대의 GPU가 필요하며, 이는 하드웨어 리소스 요구 사항이 작지 않음을 시사합니다.

--- a/src/content/models/sakana-marlin.md
+++ b/src/content/models/sakana-marlin.md
@@ -1,0 +1,32 @@
+---
+modelId: sakana-marlin
+domain: llm
+status: published
+updated: 2026-04-29
+sources:
+  - https://sakana.ai/marlin-beta/
+  - https://sakana.ai/ab-mcts-jp/
+  - https://openreview.net/forum?id=jAsr5GHt3P
+features:
+  toolUse: true
+  extendedThinking: true
+highlights:
+  - "AB-MCTS(적응형 분기 몬테카를로 트리 탐색) 기술 탑재"
+  - "8시간 이상의 자율 리서치 수행 가능"
+  - "NeurIPS 2025 Spotlight 논문 기술 기반"
+relatedOrganization: sakana-ai
+---
+
+# Sakana Marlin 소개
+
+## 개요
+Sakana Marlin은 2026년 4월 2일 Sakana AI가 발표한 비즈니스용 자율형 리서치 에이전트 시스템입니다. 고성능 전략 기획 및 고도화된 의사결정 지원을 목적으로 설계되었으며, 사용자가 주제를 입력하면 인공지능이 최장 8시간 동안 자율적으로 리서치를 수행하여 수십 페이지의 구조화된 보고서와 요약 슬라이드를 생성합니다. 이는 단순한 채팅 서비스를 넘어 전문적인 실무를 지원하는 '가상 CSO(Chief Strategy Officer)'로서의 역할을 목표로 합니다.
+
+## 기술 특징
+Marlin의 핵심 기술은 효율적인 추론 스케이링(Inference Scaling)을 구현하는 AB-MCTS(Adaptive Branching Monte Carlo Tree Search)입니다. 이 기술은 추론 과정을 나무 형태의 탐색으로 간주하여 어떤 가설이 유망한지 평가하고 계산 자원을 집중할 경로를 자율적으로 판단합니다. NeurIPS 2025에서 Spotlight로 선정된 이 알고리즘을 통해 Marlin은 수천 번의 시행착오를 거치며 논점을 심화하거나 가설을 기각하는 등 전략적인 탐색을 수행합니다. 또한 'AI 사이언티스트' 연구에서 얻은 워크플로우 자율화 노하우를 결합하여 인간의 개입 없이 완결된 결과물을 도출합니다.
+
+## 사용 사례
+Sakana Marlin은 금융기관 및 기업의 경영전략부서, 컨설팅 팜, 씽크탱크 등 고도화된 조사가 필요한 영역에서 활용됩니다. 예를 들어, 지정학적 리스크 분석과 공급망 영향 평가와 같은 복잡한 주제에 대해 60페이지 이상의 상세 보고서를 생성할 수 있습니다. 또한 금융업계의 AI 트렌드 분석과 같은 실무 레벨의 변화를 특정하고 시나리오별 구체적인 시사점을 도출하는 데 사용됩니다.
+
+## 한계
+현재 Sakana Marlin은 클로즈드 베타 테스트 단계에 있으며, 모든 기능이 일반에 공개되지는 않았습니다. 또한 복잡한 비즈니스 환경에서의 불확실성을 다루기 위해 수 시간의 연산 시간이 필요하며, 이는 실시간 응답이 필요한 간단한 질의응답에는 적합하지 않을 수 있습니다.

--- a/src/data/journal/2026-04-29-profile-model.md
+++ b/src/data/journal/2026-04-29-profile-model.md
@@ -1,0 +1,27 @@
+---
+date: 2026-04-29
+agent: profile-model
+status: completed
+summary: "Mistral Medium 3.5 및 Sakana Marlin 모델 상세 프로파일 작성 완료"
+---
+
+## Todo
+- [x] Mistral Medium 3.5 프로파일 작성 및 게시
+- [x] Sakana Marlin 프로파일 작성 및 게시
+
+## 조사 내역
+- 18:30 작업 시작. 대상 선정: mistral-medium-3-5, sakana-marlin.
+- 18:40 Mistral Medium 3.5 관련 소스 확보: 공식 문서, 블로그, NVIDIA 빌드 페이지.
+- 18:45 Sakana Marlin 관련 소스 확보: 베타 공지 블로그, AB-MCTS 기술 블로그, NeurIPS 2025 Spotlight 논문 링크.
+
+## 수행한 작업
+- [x] `src/content/models/mistral-medium-3-5.md` 생성 (status: published)
+- [x] `src/content/models/sakana-marlin.md` 생성 (status: published)
+
+## 판단 / 고민
+- 두 모델 모두 공식 소스 및 기술 블로그를 통해 3개 이상의 검증된 출처를 확보할 수 있어 'published' 상태로 등록함.
+- Mistral Medium 3.5는 멀티모달 및 코딩 에이전트 성능을 강조하고 있어 해당 기능을 특징으로 명시함.
+- Sakana Marlin은 시스템에 가깝지만 LLM 기반의 자율 추론을 핵심으로 하므로 모델 프로파일로 작성함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Added detailed profile pages for Mistral Medium 3.5 and Sakana Marlin. Both models are registered as 'published' with at least 3 verified sources each, adhering to the project's content guidelines. The profiles include overview, technical features, use cases, and limitations in Korean. Temporary logs were removed and the build was verified.

Fixes #39

---
*PR created automatically by Jules for task [10961434640110586588](https://jules.google.com/task/10961434640110586588) started by @GGJJack*