### PR TITLE
feat: Mistral 3 benchmark collection & SWE-bench registration

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -70,6 +70,20 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "swe-bench-verified",
+      "name": "SWE-bench Verified",
+      "nameKo": "소프트웨어 엔지니어링 벤치마크 (검증)",
+      "category": "coding",
+      "description": "실제 GitHub 이슈 해결 능력을 평가하는 벤치마크 (검증된 부분집합)",
+      "source": "https://www.swebench.com/",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -120,6 +134,13 @@
         "value": 9.5,
         "date": "2025-05-22",
         "source": "community"
+      }
+    },
+    "mistral-medium-3-5": {
+      "swe-bench-verified": {
+        "value": 77.6,
+        "date": "2026-04-30",
+        "source": "official"
       }
     }
   }

--- a/src/data/issues/2026-04-30-collect-benchmark-mistral-large-3.md
+++ b/src/data/issues/2026-04-30-collect-benchmark-mistral-large-3.md
@@ -1,0 +1,14 @@
+---
+created: 2026-04-30
+agent: collect-benchmark
+severity: minor
+target: llm/mistral-large-3
+---
+
+## 상황  https://mistral.ai/news/mistral-3
+- Mistral Large 3 모델의 구체적인 벤치마크 점수(MMLU, HumanEval 등)가 블로그 게시글에서 명확히 확인되지 않음.
+## 시도한 것
+- 관련 뉴스 등 검색했으나 정확한 수치를 확인할 수 없었음. (이전 검색 결과의 신뢰성 문제로 데이터 삭제 처리함)
+## 요청
+- Mistral Large 3 모델의 정확한 벤치마크 점수를 신뢰할 수 있는 출처를 통해 탐색하여 등록할 것.
+## 진행 내역

--- a/src/data/issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md
+++ b/src/data/issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md
@@ -1,0 +1,14 @@
+---
+created: 2026-04-30
+agent: collect-benchmark
+severity: minor
+target: llm/mistral-medium-3-5
+---
+
+## 상황  https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
+- Mistral Medium 3.5 모델의 HumanEval 점수가 공식 블로그 포스트나 모델 카드에 기재되어 있지 않음. SWE-bench Verified (77.6%) 만 확인됨.
+## 시도한 것
+- 관련 뉴스, Hugging Face 모델 카드, Ollama 등을 검색했으나 명확한 HumanEval 점수를 찾을 수 없었음.
+## 요청
+- Mistral Medium 3.5 모델의 HumanEval 점수를 다른 신뢰할 수 있는 출처나 커뮤니티 리더보드에서 탐색하여 등록할 것.
+## 진행 내역

--- a/src/data/journal/2026-04-30-collect-benchmark.md
+++ b/src/data/journal/2026-04-30-collect-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-04-30
+agent: collect-benchmark
+status: completed
+summary: "신규 벤치마크 (SWE-bench Verified) 등록 및 Mistral Medium 3.5 점수 확인"
+---
+
+## Todo
+- [x] Mistral Large 3 점수 등록 시도 (확인 실패 -> 이슈 티켓 생성)
+- [x] Mistral Medium 3.5 점수 등록 (SWE-bench Verified) 및 HumanEval 이슈 생성
+- [x] SWE-bench Verified 벤치마크 신규 등록
+
+## 조사 내역
+- 16:50  Mistral Medium 3.5의 SWE-bench Verified 점수 (77.6%) 확인 ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
+- 16:55  Mistral Medium 3.5의 HumanEval 점수 확인 실패 (공식 블로그에 미기재) ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
+- 17:00  Mistral Large 3의 MMLU, HumanEval 점수 정확한 출처 확인 실패 (공식 블로그 미기재) ← https://mistral.ai/news/mistral-3
+
+## 수행한 작업
+- [x] 신규 벤치마크 등록: swe-bench-verified (소프트웨어 엔지니어링 벤치마크 검증) ← https://www.swebench.com/
+- [x] mistral-medium-3-5 점수 추가: swe-bench-verified(77.6, official) ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
+
+## 판단 / 고민
+- Mistral Medium 3.5 공식 블로그에 SWE-bench Verified 점수가 강조되어 해당 벤치마크를 신규 등록함.
+- Mistral Large 3 및 Mistral Medium 3.5의 일부 벤치마크 점수는 확실한 공식/커뮤니티 출처가 불분명하여 추측을 방지하기 위해 저장하지 않고 이슈 티켓을 생성함.
+
+## 이슈 제기
+- issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md (Mistral Medium 3.5 HumanEval 점수 누락)
+- issues/2026-04-30-collect-benchmark-mistral-large-3.md (Mistral Large 3 MMLU, HumanEval 등 점수 누락)


### PR DESCRIPTION
This PR addresses the automated collection of benchmark scores for the Mistral 3 models on 2026-04-30.

- Created a new benchmark `swe-bench-verified`.
- Added the `swe-bench-verified` official score for `mistral-medium-3-5`.
- Attempted to locate `MMLU` and `HumanEval` scores for `mistral-large-3` and `mistral-medium-3-5` but due to lack of strict source verification, created issues instead (as per `AGENTS.md`).
- Documented process in journal `2026-04-30-collect-benchmark.md`.

---
*PR created automatically by Jules for task [13751328955057519481](https://jules.google.com/task/13751328955057519481) started by @GGJJack*