### PR TITLE
[collect-llm] 2026-05-01 Update: Mistral 3 Family & Reasoning Variants

### DIFF
--- a/src/data/journal/2026-05-01-collect-llm.md
+++ b/src/data/journal/2026-05-01-collect-llm.md
@@ -1,0 +1,41 @@
+---
+status: completed
+skill: collect-llm
+date: 2026-05-01
+---
+
+# 2026-05-01 collect-llm 저널
+
+## 수집 계획
+- [x] 신규 모델 발견 (목표: 1~3건)
+- [x] 기존 모델 보강 (목표: 3~5건)
+- [x] 교차 발견 확인 (TTS/STT 등)
+
+## 작업 내역
+
+### 1. 신규 모델 발견 및 등록
+- **Ministral 3 14B Reasoning**: Mistral 3 제품군의 14B 추론 최적화 모델.
+  - `pricing`: $0.20/$0.20 per 1M tokens.
+  - `links.official`: https://mistral.ai/news/mistral-3
+- **Ministral 3 8B Reasoning**: Mistral 3 제품군의 8B 추론 최적화 모델.
+  - `pricing`: $0.15/$0.15 per 1M tokens.
+  - `links.official`: https://mistral.ai/news/mistral-3
+- **Ministral 3 3B Reasoning**: Mistral 3 제품군의 3B 추론 최적화 모델.
+  - `pricing`: $0.10/$0.10 per 1M tokens.
+  - `links.official`: https://mistral.ai/news/mistral-3
+
+### 2. 기존 모델 보강
+- **Mistral 3 8B / 3B**:
+  - `pricing`: $0.15/$0.15 (8B), $0.10/$0.10 (3B) per 1M tokens.
+  - `license`: "Apache-2.0" (공식 발표에 따라 Proprietary에서 수정).
+- **Mistral Large 3 / Ministral 3 14B**:
+  - `license`: "Apache-2.0" (기존 Proprietary에서 수정).
+
+### 3. 미결 이슈 및 보류
+- **GPT-5.5**: OpenAI 공식 블로그 외에 구체적인 파라미터나 가격 정보 미확인으로 null 유지.
+- **Sakana Fugu Series**: 공식 베타 페이지(https://sakana.ai/fugu-beta/)에서 성능 벤치마크는 공개되었으나 세부 스펙(파라미터 수) 및 가격은 비공개 상태로 null 유지.
+
+## 완료 기준 확인
+- [x] 저널 frontmatter `status: completed` 설정
+- [x] 추측 데이터 배제 (공공 메모 및 공식 링크 기반)
+- [x] 확인 실패 건은 추후 보강 과제로 유지

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -289,7 +289,7 @@
       "name": "Mistral Large 3",
       "provider": "Mistral AI",
       "releaseDate": "2026-04-27",
-      "license": "Proprietary"
+      "license": "Apache-2.0"
     },
     {
       "parameterSize": "119B (6.5B active)",
@@ -363,7 +363,7 @@
       "name": "Ministral 3 14B",
       "provider": "Mistral AI",
       "releaseDate": "2026-04-27",
-      "license": "Proprietary"
+      "license": "Apache-2.0"
     },
     {
       "parameterSize": null,
@@ -410,7 +410,10 @@
     {
       "parameterSize": "8B (dense)",
       "contextWindow": 128000,
-      "pricing": null,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
       "links": {
         "official": "https://mistral.ai/news/mistral-3"
       },
@@ -418,12 +421,15 @@
       "name": "Mistral 3 8B",
       "provider": "Mistral AI",
       "releaseDate": "2026-04-27",
-      "license": "Proprietary"
+      "license": "Apache-2.0"
     },
     {
       "parameterSize": "3B (dense)",
       "contextWindow": 128000,
-      "pricing": null,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1
+      },
       "links": {
         "official": "https://mistral.ai/news/mistral-3"
       },
@@ -431,7 +437,55 @@
       "name": "Mistral 3 3B",
       "provider": "Mistral AI",
       "releaseDate": "2026-04-27",
-      "license": "Proprietary"
+      "license": "Apache-2.0"
+    },
+    {
+      "parameterSize": "14B (dense)",
+      "contextWindow": 128000,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
+      "links": {
+        "official": "https://mistral.ai/news/mistral-3"
+      },
+      "id": "ministral-3-14b-reasoning",
+      "name": "Ministral 3 14B Reasoning",
+      "provider": "Mistral AI",
+      "releaseDate": "2026-04-27",
+      "license": "Apache-2.0"
+    },
+    {
+      "parameterSize": "8B (dense)",
+      "contextWindow": 128000,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
+      "links": {
+        "official": "https://mistral.ai/news/mistral-3"
+      },
+      "id": "ministral-3-8b-reasoning",
+      "name": "Ministral 3 8B Reasoning",
+      "provider": "Mistral AI",
+      "releaseDate": "2026-04-27",
+      "license": "Apache-2.0"
+    },
+    {
+      "parameterSize": "3B (dense)",
+      "contextWindow": 128000,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1
+      },
+      "links": {
+        "official": "https://mistral.ai/news/mistral-3"
+      },
+      "id": "ministral-3-3b-reasoning",
+      "name": "Ministral 3 3B Reasoning",
+      "provider": "Mistral AI",
+      "releaseDate": "2026-04-27",
+      "license": "Apache-2.0"
     }
   ]
 }


### PR DESCRIPTION
I have completed the LLM metadata collection for 2026-05-01.

Key changes:
- **Mistral 3 Series Enrichment**: Updated the license to Apache-2.0 for Mistral Large 3, Ministral 3 14B, and Mistral 3 8B/3B. Added official pricing for the 8B and 3B models.
- **New Model Registration**: Registered the newly announced 'Reasoning' variants for the Ministral 3 series (14B, 8B, 3B) with their respective pricing and specs.
- **Journal Documentation**: Created and finalized `src/data/journal/2026-05-01-collect-llm.md` to record all discoveries and updates.
- **Verification**: Validated the project integrity with `bun run build` and verified the leaderboard changes via Playwright.

Unconfirmed metadata for GPT-5.5 and Sakana Fugu remains as `null` to maintain data quality, as per the project's mission guidelines.

Fixes #53

---
*PR created automatically by Jules for task [7435802054400348614](https://jules.google.com/task/7435802054400348614) started by @GGJJack*