### PR TITLE
Collect Benchmark data for Gemini 3.1 Pro

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -98,6 +98,20 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "gpqa",
+      "name": "GPQA",
+      "nameKo": "GPQA",
+      "category": "reasoning",
+      "description": "448 multiple-choice questions written by domain experts in biology, physics, and chemistry",
+      "source": "https://arxiv.org/abs/2311.12022",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {

--- a/src/data/issues/2026-05-01-collect-benchmark-gemini-3.1-pro.md
+++ b/src/data/issues/2026-05-01-collect-benchmark-gemini-3.1-pro.md
@@ -1,0 +1,19 @@
+---
+created: 2026-05-01
+agent: collect-benchmark
+severity: major
+target: llm/gemini-3.1-pro
+---
+
+## 상황
+Gemini 3.1 Pro 벤치마크 점수를 `https://llm-stats.com` 에서 수집하려 했으나, GPQA의 경우 94.3% 라는 점수가 보이나 "verified" 출처 URL을 찾을 수 없었음.
+MMLU, HumanEval, GSM8K 리더보드에는 Gemini 3.1 Pro 점수가 아예 누락되어 있음.
+
+## 시도한 것
+- https://llm-stats.com/benchmarks/gpqa 확인
+- https://llm-stats.com/benchmarks/mmlu 확인
+- https://llm-stats.com/benchmarks/humaneval 확인
+- https://llm-stats.com/benchmarks/gsm8k 확인
+
+## 요청
+Gemini 3.1 Pro의 공식 또는 신뢰할 수 있는 커뮤니티 출처 벤치마크 점수 (GPQA, MMLU, HumanEval, GSM8K 등) 검색 및 수집 후 `benchmark.ts` 로 추가 필요.

--- a/src/data/journal/2026-05-01-collect-benchmark.md
+++ b/src/data/journal/2026-05-01-collect-benchmark.md
@@ -1,0 +1,16 @@
+---
+date: 2026-05-01
+agent: collect-benchmark
+status: completed
+summary: "Gemini 3.1 Pro 등 벤치마크 점수 수집 시도"
+---
+
+## Todo
+- Gemini 3.1 Pro 벤치마크 점수 수집
+## 조사 내역
+- 01:30 GPQA 점수 94.3% 확인 (출처 URL 불분명) ← https://llm-stats.com/benchmarks/gpqa
+- 01:30 MMLU, HumanEval, GSM8K 리더보드에 점수 없음
+## 수행한 작업
+- [x] GPQA 벤치마크 정의 추가 (스크립트로 삭제했던 것 복구)
+## 이슈 제기
+- issues/2026-05-01-collect-benchmark-gemini-3.1-pro.md 생성


### PR DESCRIPTION
Collected benchmark data for Gemini 3.1 Pro. Validated that scores found on aggregator websites lack proper primary source citations. An issue ticket was created in `src/data/issues` as per protocol, and no scores were saved. Also restored the GPQA benchmark definition.

---
*PR created automatically by Jules for task [7556004862430653450](https://jules.google.com/task/7556004862430653450) started by @GGJJack*