### PR TITLE
Add profiles for Ministral 3 14B Reasoning and Claude Sonnet 4.6

### DIFF
--- a/src/content/models/claude-sonnet-4-6.md
+++ b/src/content/models/claude-sonnet-4-6.md
@@ -1,0 +1,35 @@
+---
+modelId: claude-sonnet-4-6
+domain: llm
+status: published
+updated: 2026-05-01
+sources:
+  - https://www.anthropic.com/news/claude-sonnet-4-6
+  - https://anthropic.com/claude-sonnet-4-6-system-card
+  - https://platform.claude.com/docs/en/about-claude/models/overview
+features:
+  toolUse: true
+  vision: true
+  extendedThinking: true
+  computerUse: true
+highlights:
+  - "1M 토큰 컨텍스트 윈도우 지원 (베타)"
+  - "컴퓨터 제어(Computer Use) 성능 대폭 개선"
+  - "적응형 사고(Adaptive Thinking) 및 확장 사고 지원"
+  - "Vending-Bench Arena 1위"
+relatedOrganization: anthropic
+---
+
+# Claude Sonnet 4.6 소개
+
+## 개요
+Claude Sonnet 4.6은 2026년 2월 Anthropic이 발표한 중급형 모델로, 성능과 효율성 사이의 완벽한 균형을 목표로 개발되었습니다. 기존 Sonnet 4.5의 가격 정책을 유지하면서도 코딩, 컴퓨터 제어, 장문 맥락 추론 등 모든 영역에서 비약적인 발전을 이루었습니다. 특히 많은 개발자들이 이전 세대의 플래그십 모델인 Claude Opus 4.5보다 Sonnet 4.6을 선호할 정도로 강력한 실전 성능을 자랑합니다.
+
+## 기술 특징
+가장 눈에 띄는 변화는 1M 토큰에 달하는 방대한 컨텍스트 윈도우를 베타 버전으로 제공한다는 점입니다. 이를 통해 대규모 코드베이스 전체나 수십 권의 연구 보고서를 한 번에 입력받아 처리할 수 있습니다. 또한 '적응형 사고(Adaptive Thinking)' 기술을 통해 문제의 난이도에 따라 사고 과정을 스스로 조절하며, '컴퓨터 제어(Computer Use)' 분야에서 OSWorld 벤치마크 점수를 대폭 끌어올려 인간에 근접한 수준의 소프트웨어 조작 능력을 보여줍니다.
+
+## 사용 사례
+Claude Sonnet 4.6은 복잡한 애플리케이션 개발 및 버그 수정, 대규모 데이터셋에 대한 금융 및 법률 분석, 그리고 다단계 에이전트 자동화 워크플로우에 최적화되어 있습니다. 특히 Vending-Bench Arena와 같은 비즈니스 전략 시뮬레이션에서 초기 투자와 후기 수익 실현이라는 고도의 장기 전략을 구사하는 능력을 입증하여, 복잡한 경영 의사 결정 지원 도구로서의 가능성을 보여주었습니다.
+
+## 한계
+여전히 고도로 복잡한 코드 리팩토링이나 여러 에이전트 간의 정교한 조율이 필요한 최상위 난이도의 작업에서는 Opus 4.6에 비해 다소 뒤처질 수 있습니다. 또한 컴퓨터 제어 기능이 크게 향상되었으나, 여전히 실제 환경에서의 예외 상황이나 모호한 사용자 지시에 대해서는 오류가 발생할 수 있어 인간의 검토가 필요합니다.

--- a/src/content/models/ministral-3-14b-reasoning.md
+++ b/src/content/models/ministral-3-14b-reasoning.md
@@ -1,0 +1,34 @@
+---
+modelId: ministral-3-14b-reasoning
+domain: llm
+status: published
+updated: 2026-05-01
+sources:
+  - https://mistral.ai/news/mistral-3
+  - https://docs.mistral.ai/models/ministral-3-14b-25-12
+  - https://arxiv.org/abs/2601.08584
+features:
+  toolUse: true
+  vision: true
+  extendedThinking: true
+highlights:
+  - "14B 파라미터 밀집(Dense) 모델"
+  - "추론 능력을 극대화한 Reasoning 버전"
+  - "AIME '25 벤치마크 85% 달성"
+  - "Apache 2.0 라이선스 적용"
+relatedOrganization: mistral-ai
+---
+
+# Ministral 3 14B Reasoning 소개
+
+## 개요
+Ministral 3 14B Reasoning은 Mistral AI가 2026년 4월에 발표한 Mistral 3 제품군의 추론 특화 모델입니다. 14B 파라미터 규모의 밀집(Dense) 아키텍처를 유지하면서도, 복잡한 논리적 사고와 수학적 문제 해결 능력을 비약적으로 향상시킨 것이 특징입니다. 온디바이스나 에지(Edge) 환경에서도 구동 가능한 크기임에도 불구하고, 폐쇄형 거대 모델에 필적하는 높은 추론 성능을 제공합니다.
+
+## 기술 특징
+이 모델은 기존 Ministral 3 14B의 멀티모달(시각 이해) 및 다국어 지원 능력을 계승하면서, 'Reasoning' 변형으로서 더 긴 시간 동안 사고하여 정확도를 높이는 메커니즘을 갖추고 있습니다. Mistral AI에 따르면, 이 모델은 수학적 성능을 측정하는 AIME '25 벤치마크에서 85%의 점수를 기록하며 해당 체급에서 세계 최고 수준의 성능을 입증했습니다. 또한 128k 토큰의 컨텍스트 윈도우를 지원하며, 40개 이상의 언어를 기본적으로 처리할 수 있습니다.
+
+## 사용 사례
+Ministral 3 14B Reasoning은 높은 논리력이 요구되는 소프트웨어 엔지니어링, 복잡한 금융 데이터 분석, 과학적 가설 검증 및 수학 문제 풀이 등에 최적화되어 있습니다. 특히 에지 디바이스에서 실행 가능한 크기이므로, 네트워크 연결이 제한된 환경에서도 고급 AI 에이전트 기능을 구현하거나 보안이 중요한 로컬 추론 작업에 효과적으로 활용될 수 있습니다.
+
+## 한계
+추론 능력을 극대화하기 위해 더 긴 사고 과정을 거치기 때문에, 일반적인 대화형 모델이나 단순 텍스트 생성 작업에서는 응답 속도가 상대적으로 느리게 느껴질 수 있습니다. 또한 시각 이해 능력을 갖추고 있으나, 오디오나 비디오와 같은 연속적인 멀티모달 데이터 처리에는 제한이 있습니다.

--- a/src/data/journal/2026-05-01-profile-model.md
+++ b/src/data/journal/2026-05-01-profile-model.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-01
+agent: profile-model
+status: completed
+summary: "Ministral 3 14B Reasoning 및 Claude Sonnet 4.6 상세 프로파일 작성 완료"
+---
+
+## Todo
+- [x] Ministral 3 14B Reasoning 프로파일 작성
+- [x] Claude Sonnet 4.6 프로파일 작성
+- [x] `bun run build` 검증
+
+## 조사 내역
+- 02:05  작업 시작. 대상 모델 선정: ministral-3-14b-reasoning, claude-sonnet-4-6.
+- 02:10  공식 출처 확인 및 정보 추출:
+  - Ministral 3: https://mistral.ai/news/mistral-3
+  - Claude Sonnet 4.6: https://www.anthropic.com/news/claude-sonnet-4-6
+- 02:20  상세 페이지 작성 시작.
+
+## 수행한 작업
+- [x] `src/content/models/ministral-3-14b-reasoning.md` 생성
+- [x] `src/content/models/claude-sonnet-4-6.md` 생성
+- [x] `bun install` 및 `bun run build`로 스키마 검증 완료
+
+## 판단 / 고민
+- Claude Sonnet 4.6의 `computerUse` 기능을 강조하기 위해 frontmatter에 해당 필드 추가.
+- Ministral 3 14B Reasoning의 뛰어난 수학 성능(AIME '25 85%)을 핵심 특징으로 서술.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This PR adds detailed profile pages for two prominent models released in early 2026: Ministral 3 14B Reasoning and Claude Sonnet 4.6. The profiles include comprehensive technical details such as context window sizes, benchmark performances (AIME '25), and new features like Computer Use and Adaptive Thinking. All content is written in Korean following the project's guidelines and verified against the Zod schema.

Fixes #58

---
*PR created automatically by Jules for task [11127928010381546872](https://jules.google.com/task/11127928010381546872) started by @GGJJack*