### PR TITLE
Collect LLM: Google Gemini 3.1 and Rakuten AI Updates

### DIFF
--- a/src/data/journal/2026-05-04-collect-llm.md
+++ b/src/data/journal/2026-05-04-collect-llm.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-04
+agent: collect-llm
+status: completed
+summary: "Google Gemini 3.1 및 Rakuten AI 추가 모델 발견 및 보강"
+---
+
+## Todo
+- [x] Gemini 3.1 Flash-Lite, Flash-Live, Robotics-ER 1.6 신규 등록
+- [x] Gemini 3.1 Flash-TTS (TTS), Flash-Image (Image-gen) 교차 등록
+- [x] Gemini 3.1 Pro 컨텍스트 윈도우 보강
+- [x] 일본 Rakuten AI 등 지역 LLM 조사 및 등록 시도
+
+## 조사 내역
+- 01:10 Google Gemini 3.1 시리즈 상세 정보 확인 (Gemini 3.1 Pro Preview, Flash-Lite Preview, Flash-Live Preview 등) ← https://ai.google.dev/gemini-api/docs/pricing
+- 01:15 Gemini 3.1 Flash-TTS, Flash-Image 등 타 도메인 모델 발견 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-tts/
+- 01:20 Gemini 3.1 Pro Preview의 정확한 컨텍스트 윈도우(1,048,576) 확인 ← https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
+
+## 수행한 작업
+- [x] Gemini 3.1 Flash-Lite, Flash-Live, Robotics-ER 1.6 신규 등록 ($/1M tokens, Context Window 정보 포함)
+- [x] Gemini 3.1 Flash-TTS (tts), Flash-Image (image-gen) 교차 등록
+- [x] Gemini 3.1 Pro 컨텍스트 윈도우 보강 (2,000,000 -> 1,048,576 공식 문서 기준)
+- [x] 일본 지역 LLM Rakuten AI 7B 시리즈 (Base, Instruct, Chat) 신규 등록
+
+## 판단 / 고민
+-
+
+## 이슈 제기
+-

--- a/src/data/models/image-gen.json
+++ b/src/data/models/image-gen.json
@@ -45,6 +45,22 @@
       "provider": "xAI",
       "releaseDate": "2026-01-28",
       "license": "Proprietary"
+    },
+    {
+      "maxResolution": null,
+      "supportedStyles": [],
+      "pricing": {
+        "input": 0.5,
+        "output": 60
+      },
+      "links": {
+        "official": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image"
+      },
+      "id": "gemini-3-1-flash-image",
+      "name": "Gemini 3.1 Flash Image",
+      "provider": "Google",
+      "releaseDate": "2026-04-22",
+      "license": "Proprietary"
     }
   ]
 }

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -103,7 +103,7 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": 2000000,
+      "contextWindow": 1048576,
       "pricing": {
         "input": 2,
         "output": 12
@@ -570,6 +570,96 @@
       "provider": "OpenAI",
       "releaseDate": "2026-04-23",
       "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 1048576,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.5
+      },
+      "links": {
+        "official": "https://ai.google.dev/gemini-api/docs/models/gemini#gemini-3.1-flash-lite"
+      },
+      "id": "gemini-3-1-flash-lite",
+      "name": "Gemini 3.1 Flash-Lite",
+      "provider": "Google",
+      "releaseDate": "2026-04-22",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5
+      },
+      "links": {
+        "official": "https://ai.google.dev/gemini-api/docs/models/gemini#gemini-3.1-flash-live"
+      },
+      "id": "gemini-3-1-flash-live",
+      "name": "Gemini 3.1 Flash-Live",
+      "provider": "Google",
+      "releaseDate": "2026-04-22",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": {
+        "input": 1,
+        "output": 5
+      },
+      "links": {
+        "official": "https://ai.google.dev/gemini-api/docs/models/gemini#gemini-robotics-er-1-6"
+      },
+      "id": "gemini-robotics-er-1-6",
+      "name": "Gemini Robotics-ER 1.6",
+      "provider": "Google",
+      "releaseDate": "2026-04-22",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": "7B",
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://corp.rakuten.co.jp/innovation/ai/",
+        "huggingface": "https://huggingface.co/Rakuten/RakutenAI-7B"
+      },
+      "id": "rakuten-ai-7b",
+      "name": "Rakuten AI 7B",
+      "provider": "Rakuten",
+      "releaseDate": "2024-03-21",
+      "license": "Apache-2.0"
+    },
+    {
+      "parameterSize": "7B",
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://corp.rakuten.co.jp/innovation/ai/",
+        "huggingface": "https://huggingface.co/Rakuten/RakutenAI-7B-instruct"
+      },
+      "id": "rakuten-ai-7b-instruct",
+      "name": "Rakuten AI 7B Instruct",
+      "provider": "Rakuten",
+      "releaseDate": "2024-03-21",
+      "license": "Apache-2.0"
+    },
+    {
+      "parameterSize": "7B",
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://corp.rakuten.co.jp/innovation/ai/",
+        "huggingface": "https://huggingface.co/Rakuten/RakutenAI-7B-chat"
+      },
+      "id": "rakuten-ai-7b-chat",
+      "name": "Rakuten AI 7B Chat",
+      "provider": "Rakuten",
+      "releaseDate": "2024-03-21",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/src/data/models/tts.json
+++ b/src/data/models/tts.json
@@ -62,6 +62,24 @@
       "provider": "xAI",
       "releaseDate": "2026-04-23",
       "license": "Proprietary"
+    },
+    {
+      "supportedLanguages": [
+        "70+ languages"
+      ],
+      "realtime": false,
+      "pricing": {
+        "input": 1,
+        "output": 20
+      },
+      "links": {
+        "official": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-tts/"
+      },
+      "id": "gemini-3-1-flash-tts",
+      "name": "Gemini 3.1 Flash TTS",
+      "provider": "Google",
+      "releaseDate": "2026-04-15",
+      "license": "Proprietary"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the newly discovered Google Gemini 3.1 series and Rakuten AI 7B series models to the model registry. It also corrects the context window for Gemini 3.1 Pro based on official documentation from the Google AI for Developers site. Relevant metadata like pricing and supported languages (for TTS) were also populated based on official sources.

Fixes #81

---
*PR created automatically by Jules for task [13591739202685293109](https://jules.google.com/task/13591739202685293109) started by @GGJJack*