### PR TITLE
Add profiles for Gemini 3.1 Flash-Lite and Rakuten AI 7B Instruct

### DIFF
--- a/src/content/models/gemini-3-1-flash-lite.md
+++ b/src/content/models/gemini-3-1-flash-lite.md
@@ -1,0 +1,34 @@
+---
+modelId: gemini-3-1-flash-lite
+domain: llm
+status: published
+updated: 2026-04-22
+sources:
+  - https://ai.google.dev/gemini-api/docs/models/gemini#gemini-3.1-flash-lite
+  - https://ai.google.dev/gemini-api/docs/pricing
+  - https://blog.google/technology/ai/google-gemini-update-2026/
+features:
+  toolUse: true
+  vision: true
+  audioInput: true
+  audioOutput: false
+highlights:
+  - "Gemini 3.1 제품군 중 가장 빠르고 비용 효율적인 멀티모달 모델"
+  - "최대 100만(1M) 토큰의 대규모 컨텍스트 창 지원"
+  - "지연 시간에 민감한 고빈도 작업 및 대규모 데이터 처리 최적화"
+relatedOrganization: google
+---
+
+# Gemini 3.1 Flash-Lite 소개
+
+## 개요
+Gemini 3.1 Flash-Lite는 2026년 4월 Google이 발표한 Gemini 3 시리즈 중 가장 빠르고 경제적인 모델입니다. 이 모델은 고성능 지능을 유지하면서도 처리 속도를 극대화하고 운영 비용을 대폭 낮추는 데 초점을 맞추어 설계되었습니다. 특히 실시간 응답이 필요한 애플리케이션이나 수백만 건의 요청을 동시에 처리해야 하는 대규모 서비스 환경에 적합한 솔루션을 제공합니다.
+
+## 기술 특징
+Gemini 3.1 Flash-Lite의 핵심 기술적 강점은 경량화된 아키텍처임에도 불구하고 100만 토큰에 달하는 방대한 컨텍스트 윈도우를 지원한다는 점입니다. 이를 통해 긴 문서 분석이나 복잡한 멀티모달 데이터(이미지, 오디오 등)를 효율적으로 처리할 수 있습니다. 또한, Gemini 3 시리즈 특유의 개선된 토큰 처리 효율성과 최적화된 추론 알고리즘을 탑재하여, 이전 세대의 경량 모델 대비 더 높은 정확도와 낮은 지연 시간을 동시에 달성했습니다.
+
+## 사용 사례
+이 모델은 즉각적인 반응이 필수적인 고객 서비스 챗봇, 실시간 언어 번역, 대량의 문서에서 특정 정보를 빠르게 추출하는 데이터 마이닝 작업에 주로 사용됩니다. 또한, 상대적으로 복잡도가 낮은 추론 작업을 저렴한 비용으로 대량 실행해야 하는 파이프라인이나, 고성능 모델(Pro/Flash)로 넘기기 전 데이터를 전처리하는 중간 단계 모델로도 매우 효과적입니다.
+
+## 한계
+Gemini 3.1 Flash-Lite는 속도와 비용에 최적화되어 있으므로, 매우 복잡한 다단계 논리 추론이나 고도의 창의적 글쓰기, 정밀한 수학적 증명 등에서는 Gemini 3.1 Pro나 Flash 모델에 비해 성능이 제한적일 수 있습니다. 또한, 공식 문서에 따르면 특정 복잡한 도구 사용(Tool Use) 시나리오에서 고성능 모델 대비 정확도가 낮아질 수 있다는 점을 고려하여 워크플로우를 설계해야 합니다.

--- a/src/content/models/rakuten-ai-7b-instruct.md
+++ b/src/content/models/rakuten-ai-7b-instruct.md
@@ -1,0 +1,32 @@
+---
+modelId: rakuten-ai-7b-instruct
+domain: llm
+status: published
+updated: 2024-03-21
+sources:
+  - https://corp.rakuten.co.jp/news/press/2024/0321_01.html
+  - https://huggingface.co/Rakuten/RakutenAI-7B-instruct
+  - https://arxiv.org/abs/2403.15484
+features:
+  toolUse: false
+  vision: false
+highlights:
+  - "Mistral-7B 기반의 일본어 최적화 오픈소스 LLM"
+  - "일본어 특화 토크나이저(48k vocabulary) 적용으로 텍스트 처리 효율 극대화"
+  - "LM Evaluation Harness 기준 오픈소스 일본어 모델 중 최상위권 성능"
+relatedOrganization: rakuten
+---
+
+# Rakuten AI 7B Instruct 소개
+
+## 개요
+Rakuten AI 7B Instruct는 2024년 3월 락텐(Rakuten) 그룹이 발표한 일본어 특화 70억 파라미터 규모의 대규모 언어 모델입니다. Mistral AI의 Mistral-7B 아키텍처를 기반으로 하며, 방대한 일본어 및 영어 데이터를 사용하여 지속적 학습(Continuous Pre-training)을 거쳤습니다. 이 모델은 특히 일본어 문맥 이해와 지시 이행(Instruction Following) 성능을 극대화하여 개발되었으며, Apache 2.0 라이선스로 공개되어 상업적 활용이 가능합니다.
+
+## 기술 특징
+Rakuten AI 7B Instruct의 가장 큰 특징은 일본어에 최적화된 독자적인 형태소 분석기(토크나이저)를 사용한다는 점입니다. 기존 32k였던 어휘 사전(Vocabulary) 규모를 48k로 확장하여, 토큰당 포함되는 평균 문자 수를 늘렸습니다. 이를 통해 텍스트 처리의 효율성을 높였으며, 동일한 컨텍스트 내에서 더 많은 정보를 처리할 수 있게 되었습니다. 성능 평가 측면에서는 LM Evaluation Harness 기준 일본어 평가에서 77.3점을 기록하며, 공개 당시 비슷한 크기의 다른 오픈소스 일본어 모델들을 상회하는 결과를 보여주었습니다.
+
+## 사용 사례
+이 모델은 일본어 요약, 질의응답, 대화 시스템 구축 등 다양한 텍스트 생성 작업에 최적화되어 있습니다. 특히 락텐 에코시스템(경제권) 내에서 고객 서비스 자동화나 일본어 기반의 비즈니스 문서 분석을 위해 활용될 수 있도록 설계되었습니다. 오픈소스 라이선스 덕분에 일본 시장을 타겟으로 하는 스타트업이나 기업들이 자체 인프라에 모델을 배포하여 보안을 유지하면서도 고성능 일본어 서비스를 구축하는 데 널리 사용될 수 있습니다.
+
+## 한계
+Rakuten AI 7B Instruct는 7B라는 모델 크기의 한계로 인해, 수천억 단위의 파라미터를 가진 초거대 모델들에 비해 복잡한 추론이나 깊이 있는 전문 지식을 요구하는 작업에서는 성능이 낮을 수 있습니다. 또한, 일본어와 영어 데이터 위주로 학습되었기 때문에 다른 언어에 대한 대응 능력은 제한적입니다. 모든 대규모 언어 모델과 마찬가지로 할루시네이션(환각) 현상이나 편향된 출력을 생성할 가능성이 있으므로, 실제 서비스 적용 시 적절한 안전 장치가 필요합니다.

--- a/src/data/journal/2026-05-04-profile-model.md
+++ b/src/data/journal/2026-05-04-profile-model.md
@@ -1,0 +1,26 @@
+---
+date: 2026-05-04
+agent: profile-model
+status: completed
+summary: "Gemini 3.1 Flash-Lite 및 Rakuten AI 7B Instruct 상세 페이지 작성 완료"
+---
+
+## Todo
+- [x] Gemini 3.1 Flash-Lite 상세 페이지 작성 (`src/content/models/gemini-3-1-flash-lite.md`)
+- [x] Rakuten AI 7B Instruct 상세 페이지 작성 (`src/content/models/rakuten-ai-7b-instruct.md`)
+
+## 조사 내역
+- 02:05 Gemini 3.1 Flash-Lite 공식 문서 확인: Gemini 3 시리즈 중 가장 빠르고 비용 효율적인 모델, 1M 컨텍스트 지원 ← https://ai.google.dev/gemini-api/docs/models/gemini#gemini-3.1-flash-lite
+- 02:10 Rakuten AI 7B 시리즈 정보 확인: Mistral-7B 기반, 일본어 최적화, Apache 2.0 라이선스 ← https://corp.rakuten.co.jp/news/press/2024/0321_01.html
+- 02:15 Rakuten AI 7B Instruct 상세 성능 지표 및 기술 리포트 확인 ← https://huggingface.co/Rakuten/RakutenAI-7B-instruct
+
+## 수행한 작업
+- [x] `src/content/models/gemini-3-1-flash-lite.md` 생성 및 작성 (status: published)
+- [x] `src/content/models/rakuten-ai-7b-instruct.md` 생성 및 작성 (status: published)
+
+## 판단 / 고민
+- Gemini 3.1 Flash-Lite는 Pro와 동일한 컨텍스트 창을 가지면서도 속도와 비용에 최적화된 점을 강조함.
+- Rakuten AI는 독자적인 형태소 분석기 적용을 통한 일본어 처리 효율성을 기술적 차별점으로 부각함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This PR adds two new model profile pages to the ModuBench platform:

1. **Gemini 3.1 Flash-Lite**: Detailed as the fastest and most cost-effective model in Google's Gemini 3 series, highlighting its 1M context window and optimized latency.
2. **Rakuten AI 7B Instruct**: Detailed as a Japanese-optimized open-source model based on Mistral-7B, featuring a specialized 48k vocabulary for efficient text processing.

The work has been documented in the `2026-05-04-profile-model.md` journal and verified through `bun run build` (Zod schema validation) and frontend screenshot capture.

Fixes #83

---
*PR created automatically by Jules for task [12594073224711403931](https://jules.google.com/task/12594073224711403931) started by @GGJJack*