### PR TITLE
Add benchmark profiles for clip-score and geneval

### DIFF
--- a/src/content/benchmarks/clip-score.md
+++ b/src/content/benchmarks/clip-score.md
@@ -1,0 +1,20 @@
+---
+benchmarkId: clip-score
+domain: image-gen
+status: published
+updated: 2026-05-04
+sources:
+  - https://arxiv.org/abs/2104.08718
+paperUrl: https://arxiv.org/abs/2104.08718
+highlights:
+  - "텍스트 프롬프트와 생성 이미지 간 의미적 유사도 평가"
+  - "참조 이미지가 필요 없는(reference-free) 자동화 평가 지표"
+---
+
+# CLIP Score
+
+## 개요
+CLIP Score는 텍스트 프롬프트와 생성된 이미지 간의 의미적 정합성을 평가하는 지표입니다. 이미지 캡셔닝 및 텍스트-이미지 생성 모델의 결과물에 대해 인간의 판단과 높은 상관관계를 보여줍니다.
+
+## 평가 방법
+대규모 이미지-텍스트 쌍(약 4억 개)으로 사전 학습된 CLIP(Contrastive Language-Image Pre-training) 모델을 사용합니다. 생성된 이미지와 텍스트 프롬프트를 각각 CLIP의 이미지 인코더와 텍스트 인코더에 통과시켜 임베딩 벡터를 추출하고, 두 벡터 간의 코사인 유사도를 계산하여 점수를 산출합니다. 참조용 정답 이미지 없이도(reference-free) 평가가 가능하다는 점이 특징입니다.

--- a/src/content/benchmarks/geneval.md
+++ b/src/content/benchmarks/geneval.md
@@ -1,0 +1,20 @@
+---
+benchmarkId: geneval
+domain: image-gen
+status: published
+updated: 2026-05-04
+sources:
+  - https://arxiv.org/abs/2310.11513
+paperUrl: https://arxiv.org/abs/2310.11513
+highlights:
+  - "객체 중심(Object-Focused)의 텍스트-이미지 정합성 평가 프레임워크"
+  - "객체 동시 등장, 위치, 개수, 색상 등 구성적(compositional) 속성 평가"
+---
+
+# GenEval
+
+## 개요
+GenEval은 텍스트-이미지 정합성을 세밀하게 평가하기 위한 객체 중심(Object-Focused)의 프레임워크입니다. FID나 CLIPScore와 같은 전체적인 이미지 품질 지표의 한계를 보완하여, 모델이 복잡한 프롬프트 내의 구성적 속성(compositionality)을 얼마나 잘 반영하는지 측정합니다.
+
+## 평가 방법
+객체의 동시 등장(co-occurrence), 위치(position), 개수(count), 색상(color) 등 다양한 구성적 속성을 평가합니다. 최신 객체 탐지(object detection) 모델을 활용해 생성된 이미지 내의 객체와 속성을 추출하고, 이것이 주어진 텍스트 프롬프트와 일치하는지 자동화된 파이프라인을 통해 검증합니다. 평가 결과는 프롬프트 속성을 정확하게 반영한 비율(%)로 산출됩니다.

--- a/src/data/journal/2026-05-04-profile-benchmark.md
+++ b/src/data/journal/2026-05-04-profile-benchmark.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-04
+agent: profile-benchmark
+status: completed
+summary: "clip-score와 geneval 벤치마크 상세 페이지 작성 완료"
+---
+
+## Todo
+- [x] image-gen 도메인의 벤치마크 (clip-score, geneval) 상세 페이지 생성
+
+## 조사 내역
+- clip-score 공식 논문 (https://arxiv.org/abs/2104.08718) 조회
+- geneval 공식 논문 (https://arxiv.org/abs/2310.11513) 조회
+
+## 수행한 작업
+- [x] `src/content/benchmarks/clip-score.md` 작성 완료 (출처: https://arxiv.org/abs/2104.08718)
+- [x] `src/content/benchmarks/geneval.md` 작성 완료 (출처: https://arxiv.org/abs/2310.11513)
+
+## 판단 / 고민
+- 제공된 도메인 리스트를 확인하고 image-gen 도메인의 벤치마크 2건을 선정하여 상세 페이지 작성
+- 두 벤치마크 모두 특정 organization에 속하는 명시적인 정보가 없어 organization stub는 생성하지 않음
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Added detailed profile pages for two image-gen benchmarks (CLIP Score and GenEval) as per the agent's scheduled task, completing the daily journaling and frontmatter validation.

---
*PR created automatically by Jules for task [13485926765983848490](https://jules.google.com/task/13485926765983848490) started by @GGJJack*