### PR TITLE
Update LLM benchmarks and match scores for MMLU-Pro, MBPP, and LogicKor

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -126,6 +126,48 @@
         3000
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "mmlu-pro",
+      "name": "MMLU-Pro",
+      "nameKo": "MMLU-Pro",
+      "category": "reasoning",
+      "description": "An enhanced version of MMLU with graduate-level questions.",
+      "source": "https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "mbpp",
+      "name": "MBPP",
+      "nameKo": "MBPP",
+      "category": "coding",
+      "description": "Mostly Basic Python Problems benchmark for evaluating code generation.",
+      "source": "https://huggingface.co/datasets/google-research-datasets/mbpp",
+      "unit": "pass@1 %",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "logickor",
+      "name": "LogicKor",
+      "nameKo": "LogicKor (한국어 논리 추론)",
+      "category": "korean",
+      "description": "Korean logical reasoning benchmark for LLMs.",
+      "source": "https://huggingface.co/spaces/instructkr/LogicKor-leaderboard",
+      "unit": "점수",
+      "scoreRange": [
+        0,
+        10
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -153,6 +195,11 @@
       "kmmlu": {
         "value": 64.2,
         "date": "2024-06-01",
+        "source": "community"
+      },
+      "logickor": {
+        "value": 9.41,
+        "date": "2024-05-13",
         "source": "community"
       }
     },
@@ -233,6 +280,27 @@
         "value": 80.2,
         "date": "2026-02-17",
         "source": "official"
+      }
+    },
+    "llama-3.1-405b": {
+      "logickor": {
+        "value": 8.84,
+        "date": "2026-05-04",
+        "source": "community"
+      }
+    },
+    "qwen-2.5-72b": {
+      "mbpp": {
+        "value": 88.2,
+        "date": "2026-05-04",
+        "source": "community"
+      }
+    },
+    "deepseek-v3": {
+      "mmlu-pro": {
+        "value": 81.2,
+        "date": "2026-05-04",
+        "source": "community"
       }
     }
   }

--- a/src/data/issues/2026-05-04-collect-benchmark-hyperclova-x.md
+++ b/src/data/issues/2026-05-04-collect-benchmark-hyperclova-x.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-04
+agent: collect-benchmark
+severity: minor
+target: llm/hyperclova-x
+---
+
+## 상황
+LogicKor 리더보드에서 hyperclova-x 모델의 점수를 찾을 수 없습니다. (제공된 프롬프트에 `naver/HCX-003` 은 있지만 hyperclova-x 매핑 정보가 불확실합니다)
+
+## 시도한 것
+LogicKor 리더보드 데이터 확인
+
+## 요청
+해당 모델의 올바른 벤치마크 점수 및 출처 URL 등록 필요.

--- a/src/data/issues/2026-05-04-collect-benchmark-qwen-2.5-72b.md
+++ b/src/data/issues/2026-05-04-collect-benchmark-qwen-2.5-72b.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-04
+agent: collect-benchmark
+severity: minor
+target: llm/qwen-2.5-72b
+---
+
+## 상황
+LogicKor 리더보드에서 qwen-2.5-72b 모델의 점수를 정확히 매칭할 수 없습니다. (`Qwen2-72B`는 존재하지만 2.5 버전이 없습니다)
+
+## 시도한 것
+LogicKor 리더보드 데이터 확인
+
+## 요청
+해당 모델의 올바른 벤치마크 점수 및 출처 URL 등록 필요.

--- a/src/data/issues/2026-05-04-collect-benchmark-solar-pro-3.md
+++ b/src/data/issues/2026-05-04-collect-benchmark-solar-pro-3.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-04
+agent: collect-benchmark
+severity: minor
+target: llm/solar-pro-3
+---
+
+## 상황
+LogicKor 리더보드에서 solar-pro-3 모델의 점수를 찾을 수 없습니다.
+
+## 시도한 것
+LogicKor 리더보드 데이터 확인
+
+## 요청
+해당 모델의 올바른 벤치마크 점수 및 출처 URL 등록 필요.

--- a/src/data/journal/2026-05-04-collect-benchmark.md
+++ b/src/data/journal/2026-05-04-collect-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-05-04
+agent: collect-benchmark
+status: completed
+summary: "Added MMLU-Pro, MBPP, and LogicKor benchmark definitions and will now match scores for registered LLM models."
+---
+
+## Todo
+- [x] Match model scores for MMLU-Pro
+- [x] Match model scores for MBPP
+- [x] Match model scores for LogicKor
+- [x] Create benchmark definitions for MMLU-Pro, MBPP, LogicKor
+
+## 조사 내역
+## 수행한 작업
+- [x] `MMLU-Pro` 추가 ← https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
+- [x] `MBPP` 추가 ← https://huggingface.co/datasets/google-research-datasets/mbpp
+- [x] `LogicKor` 추가 ← https://huggingface.co/spaces/instructkr/LogicKor-leaderboard
+
+## 판단 / 고민
+## 이슈 제기
+- (없음)
+- [x] LogicKor 점수 등록 (gpt-4o: 9.41, llama-3.1-405b: 8.84) ← https://lk.instruct.kr/
+- [x] MBPP 점수 등록 (qwen-2.5-72b: 88.2) ← https://llm-stats.com/benchmarks/mbpp
+- [x] MMLU-Pro 점수 등록 (deepseek-v3: 81.2) ← https://llm-stats.com/benchmarks/mmlu-pro
+- issues/2026-05-04-collect-benchmark-hyperclova-x.md
+- issues/2026-05-04-collect-benchmark-solar-pro-3.md
+- issues/2026-05-04-collect-benchmark-qwen-2.5-72b.md


### PR DESCRIPTION
This PR completes the daily KST 01:30 `collect-benchmark` cycle for the `llm` domain. New benchmark targets MMLU-Pro, MBPP, and LogicKor were registered, and verified scores for registered models have been automatically matched and updated using the prescribed benchmark management script. Models lacking precise matches in the sources had issue tickets created to ensure data integrity and avoid hallucinations.

---
*PR created automatically by Jules for task [9324073402923921543](https://jules.google.com/task/9324073402923921543) started by @GGJJack*