### PR TITLE
feat: create daily report for 2026-05-04

### DIFF
--- a/src/data/journal/2026-05-05-journal.md
+++ b/src/data/journal/2026-05-05-journal.md
@@ -1,0 +1,25 @@
+---
+date: 2026-05-05
+agent: journal
+status: completed
+summary: "Compiled the daily report for 2026-05-04 by reading the collect and profile journals."
+---
+
+## Todo
+- [x] Read agent journals for the previous day (2026-05-04)
+- [x] Generate the daily report mapping to `src/data/updates/2026-05-04-daily.md`
+
+## 조사 내역
+- 2026-05-04-collect-benchmark.md
+- 2026-05-04-collect-llm.md
+- 2026-05-04-profile-benchmark.md
+- 2026-05-04-profile-model.md
+
+## 수행한 작업
+- [x] `src/data/updates/2026-05-04-daily.md` 데일리 리포트 발행 완료
+
+## 판단 / 고민
+- (없음)
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-04-daily.md
+++ b/src/data/updates/2026-05-04-daily.md
@@ -1,0 +1,36 @@
+---
+date: 2026-05-04
+type: note
+title: 데일리 리포트 · 2026-05-04
+summary: Gemini 3.1, Rakuten AI 모델 신규 등록 및 MMLU-Pro, MBPP, LogicKor 벤치마크 추가
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: Gemini 3.1 Flash-Lite, Gemini 3.1 Flash-Live, Gemini 3.1 Robotics-ER 1.6 (https://ai.google.dev/gemini-api/docs/pricing)
+- 신규: Rakuten AI 7B Base, Instruct, Chat (https://corp.rakuten.co.jp/news/press/2024/0321_01.html)
+- 교차 등록: Gemini 3.1 Flash-TTS (tts), Gemini 3.1 Flash-Image (image-gen)
+- 보강: Gemini 3.1 Pro · Context Window (2,000,000 -> 1,048,576)
+
+### 벤치마크 (collect-benchmark)
+- 신규: MMLU-Pro (https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro)
+- 신규: MBPP (https://huggingface.co/datasets/google-research-datasets/mbpp)
+- 신규: LogicKor (https://huggingface.co/spaces/instructkr/LogicKor-leaderboard)
+- 점수 등록: LogicKor (gpt-4o: 9.41, llama-3.1-405b: 8.84)
+- 점수 등록: MBPP (qwen-2.5-72b: 88.2)
+- 점수 등록: MMLU-Pro (deepseek-v3: 81.2)
+
+## 상세 페이지 작성 (profile)
+- models/gemini-3-1-flash-lite · status=published
+- models/rakuten-ai-7b-instruct · status=published
+- benchmarks/clip-score · status=published
+- benchmarks/geneval · status=published
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 0건
+
+## 미해결 이슈
+- issues/2026-05-04-collect-benchmark-hyperclova-x.md — LogicKor 리더보드 점수 누락
+- issues/2026-05-04-collect-benchmark-solar-pro-3.md — LogicKor 리더보드 점수 누락
+- issues/2026-05-04-collect-benchmark-qwen-2.5-72b.md — LogicKor 리더보드 점수 누락


### PR DESCRIPTION
Creates the daily report for 2026-05-04 based on the journal agent's instructions, extracting new additions, benchmarks, profile statuses, and unresolved issues.

Also creates the journal entry for the agent marking it completed.

---
*PR created automatically by Jules for task [2931627350692772935](https://jules.google.com/task/2931627350692772935) started by @GGJJack*