### PR TITLE
chore: collect benchmark scores for new models

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -302,6 +302,74 @@
         "date": "2026-05-04",
         "source": "community"
       }
+    },
+    "gemini-3-1-flash-lite": {
+      "gpqa": {
+        "value": 86.9,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "mmlu": {
+        "value": 89.2,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "mmlu-pro": {
+        "value": 83,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "humaneval": {
+        "value": 90.5,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "gsm8k": {
+        "value": 96.2,
+        "date": "2026-05-05",
+        "source": "community"
+      }
+    },
+    "gemini-3-1-flash-live": {
+      "gpqa": {
+        "value": 94,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "mmlu": {
+        "value": 91,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "mmlu-pro": {
+        "value": 89,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "humaneval": {
+        "value": 73,
+        "date": "2026-05-05",
+        "source": "community"
+      },
+      "gsm8k": {
+        "value": 99,
+        "date": "2026-05-05",
+        "source": "community"
+      }
+    },
+    "rakuten-ai-7b": {
+      "mmlu": {
+        "value": 61.31,
+        "date": "2026-05-05",
+        "source": "official"
+      }
+    },
+    "rakuten-ai-7b-instruct": {
+      "mmlu": {
+        "value": 60.32,
+        "date": "2026-05-05",
+        "source": "official"
+      }
     }
   }
 }

--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -1,0 +1,18 @@
+---
+created: 2026-05-05
+agent: collect-benchmark
+severity: minor
+target: llm/gemini-robotics-er-1-6
+---
+
+## 상황
+Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티 사이트에서 찾을 수 없음.
+
+## 시도한 것
+- Google AI Docs 확인 (https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview)
+- Automatio AI, HuggingFace 등 커뮤니티 리더보드 검색
+
+## 요청
+향후 Gemini Robotics-ER 1.6 에 대한 벤치마크 (MMLU, GPQA 등) 점수가 공개되면 추가 요망.
+
+## 진행 내역

--- a/src/data/issues/2026-05-05-collect-benchmark-rakuten-ai-7b-chat.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-rakuten-ai-7b-chat.md
@@ -1,0 +1,17 @@
+---
+created: 2026-05-05
+agent: collect-benchmark
+severity: minor
+target: llm/rakuten-ai-7b-chat
+---
+
+## 상황
+Rakuten AI 7B Chat 모델의 벤치마크 점수(MMLU 등)가 모델 공식 문서에서 확인되지 않음. Instruct 모델의 점수만 존재함.
+
+## 시도한 것
+- HuggingFace 공식 모델 페이지 (https://huggingface.co/Rakuten/RakutenAI-7B-chat) 확인
+
+## 요청
+Rakuten AI 7B Chat 모델에 대한 구체적인 벤치마크 수치가 공개되면 추가 요망.
+
+## 진행 내역

--- a/src/data/journal/2026-05-05-collect-benchmark.md
+++ b/src/data/journal/2026-05-05-collect-benchmark.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-05
+agent: collect-benchmark
+status: completed
+summary: "Discover and add benchmark scores for newly registered LLM models"
+---
+
+## Todo
+- [x] Find benchmark scores for newly added LLMs.
+- [x] Update benchmarks using the `benchmark.ts` script.
+
+## 조사 내역
+- 02:10 Gemini 3.1 Flash-Lite 벤치마크 점수 확인 (MMLU 89.2, MMLU Pro 83.0, GPQA 86.9, HumanEval 90.5, GSM8K 96.2) ← https://automatio.ai/models/gemini-3-1-flash-lite
+- 02:15 Gemini 3.1 Flash-Live 벤치마크 점수 확인 (MMLU 91.0, MMLU Pro 89.0, GPQA 94.0, HumanEval 73.0, GSM8K 99.0) ← https://automatio.ai/models/gemini-3-1-flash-live
+- 02:20 Rakuten AI 7B 벤치마크 점수 확인 (MMLU 61.31) ← https://huggingface.co/Rakuten/RakutenAI-7B
+- 02:22 Rakuten AI 7B Instruct 벤치마크 점수 확인 (MMLU 60.32) ← https://huggingface.co/Rakuten/RakutenAI-7B-instruct
+- 02:25 Rakuten AI 7B Chat 벤치마크 점수 미확인 ← https://huggingface.co/Rakuten/RakutenAI-7B-chat
+
+## 수행한 작업
+- [x] Gemini 3.1 Flash-Lite 벤치마크 점수 추가 완료 (MMLU, MMLU-Pro, GPQA, HumanEval, GSM8K) ← https://automatio.ai/models/gemini-3-1-flash-lite
+- [x] Gemini 3.1 Flash-Live 벤치마크 점수 추가 완료 (MMLU, MMLU-Pro, GPQA, HumanEval, GSM8K) ← https://automatio.ai/models/gemini-3-1-flash-live
+- [x] Rakuten AI 7B 벤치마크 점수 추가 완료 (MMLU) ← https://huggingface.co/Rakuten/RakutenAI-7B
+- [x] Rakuten AI 7B Instruct 벤치마크 점수 추가 완료 (MMLU) ← https://huggingface.co/Rakuten/RakutenAI-7B-instruct
+
+## 판단 / 고민
+- Gemini Robotics-ER 1.6 및 Rakuten AI 7B Chat 의 벤치마크 점수는 공식/커뮤니티 사이트에서 명확하게 확인되지 않아 추가하지 않고 이슈 티켓을 생성함.
+
+## 이슈 제기
+- issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+- issues/2026-05-05-collect-benchmark-rakuten-ai-7b-chat.md


### PR DESCRIPTION
This PR completes the `collect-benchmark` task for newly added LLM models on May 5th, 2026.

I collected benchmark scores for Gemini 3.1 Flash-Lite, Gemini 3.1 Flash-Live, and Rakuten AI 7B models from verified sources and updated the `llm.json` using the `benchmark.ts` script.

In compliance with the project rules, I did not hallucinate or guess scores for Gemini Robotics-ER 1.6 and Rakuten AI 7B Chat. Instead, I created issue tickets in `src/data/issues/` for further investigation.

I also thoroughly documented all URLs and actions taken in the daily journal at `src/data/journal/2026-05-05-collect-benchmark.md`.

---
*PR created automatically by Jules for task [2329478175115642526](https://jules.google.com/task/2329478175115642526) started by @GGJJack*