### PR TITLE
doc: add daily report and journal for 2026-05-06

### DIFF
--- a/src/data/journal/2026-05-07-journal.md
+++ b/src/data/journal/2026-05-07-journal.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-07
+agent: journal
+status: completed
+summary: "Compiled the daily report for 2026-05-06 by reading the collect, profile, and reinforce journals."
+---
+
+## Todo
+- [x] Read agent journals for the previous day (2026-05-06)
+- [x] Generate the daily report mapping to `src/data/updates/2026-05-06-daily.md`
+
+## 조사 내역
+- 2026-05-06-collect-llm.md
+- 2026-05-06-profile-benchmark.md
+- 2026-05-06-profile-model.md
+
+## 수행한 작업
+- [x] `src/data/updates/2026-05-06-daily.md` 데일리 리포트 발행 완료
+
+## 판단 / 고민
+- (없음)
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-06-daily.md
+++ b/src/data/updates/2026-05-06-daily.md
@@ -1,0 +1,31 @@
+---
+date: 2026-05-06
+type: note
+title: 데일리 리포트 · 2026-05-06
+summary: 2026년 5월 6일 수집된 LLM 도메인 모델, 벤치마크 업데이트, 모델 프로파일 작성 내역 요약
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: `yi-1-5-34b-chat`, `baichuan2-13b-chat`, `glm-4-9b-chat`, `yi-large`, `glm-4-flash`, `baichuan-4`
+- 보강: `minimax-m2-7` · contextWindow(1M), pricing(5/15)
+- 보강: `qwen-plus`, `qwen-turbo` · pricing(0.4/1.2, 0.1/0.3)
+- 보강: `solar-pro-3` · parameterSize(31B), contextWindow(128k), pricing(0.5/0.5)
+- 보강: `gpt-5-3-instant` · contextWindow(128k), pricing(0.1/0.4)
+- 보강: `hyperclova-x` · contextWindow(32k)
+- 보강: `exaone-3.0` · parameterSize(7.8B), contextWindow(32k), links 추가
+
+### 벤치마크 (collect-benchmark)
+- 신규: `logickor` (출처: https://lk.instruct.kr/, https://github.com/instructkr/LogicKor 등)
+- 조직 스텁: `instructkr` 스텁 추가 (출처: https://huggingface.co/instructkr)
+
+## 상세 페이지 작성 (profile)
+- models/exaone-3.0.md · status=completed
+- models/deepseek-v3.md · status=completed
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 0건
+
+## 미해결 이슈
+- issues/2026-05-06-collect-llm-pricing-missing.md — Baichuan-4, Yi-Large 등 가격 및 파라미터 정보 부재 이슈


### PR DESCRIPTION
- Created `src/data/updates/2026-05-06-daily.md` with a summary of activities from collect, profile, and reinforce journals from 2026-05-06. Extracted numbers and activities precisely from the relevant journals.
- Generated the self-journal entry `src/data/journal/2026-05-07-journal.md` reflecting the successful creation of the daily report. Validated schema validations via `bun run build`.

---
*PR created automatically by Jules for task [14507188724717339145](https://jules.google.com/task/14507188724717339145) started by @GGJJack*