### PR TITLE
chore: collect benchmark scores for newly registered LLMs (2026-05-07)

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -412,6 +412,32 @@
         "source": "official",
         "sourceUrl": "https://arxiv.org/abs/2601.08584"
       }
+    },
+    "glm-4-9b-chat": {
+      "mmlu": {
+        "value": 72.4,
+        "date": "2024-06-18",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/zai-org/glm-4-9b-chat"
+      },
+      "gsm8k": {
+        "value": 79.6,
+        "date": "2024-06-18",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/zai-org/glm-4-9b-chat"
+      },
+      "humaneval": {
+        "value": 71.8,
+        "date": "2024-06-18",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/zai-org/glm-4-9b-chat"
+      },
+      "mt-bench": {
+        "value": 8.35,
+        "date": "2024-06-18",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/zai-org/glm-4-9b-chat"
+      }
     }
   }
 }

--- a/src/data/issues/2026-05-07-collect-benchmark-baichuan2-13b-chat.md
+++ b/src/data/issues/2026-05-07-collect-benchmark-baichuan2-13b-chat.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-07
+agent: collect-benchmark
+severity: minor
+target: llm/baichuan2-13b-chat
+---
+
+## 상황  https://huggingface.co/baichuan-inc/Baichuan2-13B-Chat
+Baichuan2-13B-Chat 의 공식 Hugging Face 모델 카드 페이지에서 Chat 모델에 대한 벤치마크 점수를 명시적으로 제공하고 있지 않음. Base 모델의 점수(MMLU 59.17)만 확인됨.
+
+## 시도한 것
+Hugging Face 모델 카드 페이지 내 벤치마크 점수 테이블 확인.
+
+## 요청
+Baichuan2-13B-Chat 모델의 벤치마크 점수를 공식 출처나 커뮤니티 리더보드에서 추가로 조사하여 반영할 것.

--- a/src/data/issues/2026-05-07-collect-benchmark-yi-1-5-34b-chat.md
+++ b/src/data/issues/2026-05-07-collect-benchmark-yi-1-5-34b-chat.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-07
+agent: collect-benchmark
+severity: minor
+target: llm/yi-1-5-34b-chat
+---
+
+## 상황  https://huggingface.co/01-ai/Yi-1.5-34B-Chat
+Yi-1.5-34B-Chat 의 벤치마크 점수가 해당 공식 모델 카드 페이지에서 이미지(png) 형태로만 제공되고 있어 텍스트 형태로 정확한 수치를 확인할 수 없음.
+
+## 시도한 것
+Hugging Face 모델 카드 페이지 텍스트 추출 및 구글 검색.
+
+## 요청
+해당 모델의 벤치마크 점수를 텍스트로 확인할 수 있는 다른 공식 출처나 커뮤니티(리더보드)를 조사하여 벤치마크 데이터를 추가할 것.

--- a/src/data/journal/2026-05-07-collect-benchmark.md
+++ b/src/data/journal/2026-05-07-collect-benchmark.md
@@ -1,0 +1,27 @@
+---
+date: 2026-05-07
+agent: collect-benchmark
+status: completed
+summary: "Discover and add benchmark scores for newly registered LLM models"
+---
+
+## Todo
+- [x] Find benchmark scores for newly added LLMs (Yi-1.5-34B-Chat, Baichuan2-13B-Chat, GLM-4-9B-Chat).
+- [x] Update benchmarks using the `benchmark.ts` script.
+
+## 조사 내역
+- 01:30 Yi-1.5-34B-Chat 벤치마크 점수 확인 (이미지 형태라 직접 확인 불가) ← https://huggingface.co/01-ai/Yi-1.5-34B-Chat
+- 01:35 Baichuan2-13B-Chat 벤치마크 점수 확인 (Base 모델의 점수만 존재하여 Chat 모델 점수 확인 불가) ← https://huggingface.co/baichuan-inc/Baichuan2-13B-Chat
+- 01:40 GLM-4-9B-Chat 벤치마크 점수 확인 (MMLU 72.4, GSM8K 79.6, HumanEval 71.8, MT-Bench 8.35) ← https://huggingface.co/zai-org/glm-4-9b-chat
+
+## 수행한 작업
+- [x] GLM-4-9B-Chat 벤치마크 점수 추가 완료 (MMLU, GSM8K, HumanEval, MT-Bench) ← https://huggingface.co/zai-org/glm-4-9b-chat
+
+## 판단 / 고민
+- Yi-1.5-34B-Chat 의 경우 공식 Hugging Face 페이지에서 벤치마크 점수가 이미지 형태로만 제공되어 텍스트 추출이 불가능함.
+- Baichuan2-13B-Chat 의 경우 Base 모델의 점수만 기재되어 있고 Chat 모델의 점수는 명시되어 있지 않음.
+- 따라서 위 두 모델의 벤치마크 점수를 부정확하게 입력하지 않고 각각 이슈 티켓을 생성함.
+
+## 이슈 제기
+- issues/2026-05-07-collect-benchmark-yi-1-5-34b-chat.md
+- issues/2026-05-07-collect-benchmark-baichuan2-13b-chat.md


### PR DESCRIPTION
This PR completes the `collect-benchmark` task for the 2026-05-07 session.
The task involved gathering benchmark scores for the newly collected LLM models: `Yi-1.5-34B-Chat`, `Baichuan2-13B-Chat`, and `GLM-4-9B-Chat`.

Changes:
- Discovered and added valid text-based scores for `GLM-4-9B-Chat` for MMLU, GSM8K, HumanEval, and MT-Bench.
- Created issue tickets for `Yi-1.5-34B-Chat` (scores presented as image) and `Baichuan2-13B-Chat` (Chat model scores missing) since specific numbers could not be reliably extracted.
- Updated the daily journal `2026-05-07-collect-benchmark.md` and set the status to `completed`.
- Verified the build succeeds.

---
*PR created automatically by Jules for task [440867758507838124](https://jules.google.com/task/440867758507838124) started by @GGJJack*