### PR TITLE
feat: add wer-librispeech-clean and mos benchmark profiles

### DIFF
--- a/src/content/benchmarks/mos.md
+++ b/src/content/benchmarks/mos.md
@@ -1,0 +1,17 @@
+---
+benchmarkId: mos
+domain: tts
+status: published
+updated: 2026-05-09
+sources:
+  - https://en.wikipedia.org/wiki/Mean_opinion_score
+organization: itu-t
+---
+
+# MOS (평균 의견 점수)
+
+## 개요
+인간 평가자의 음성 자연스러움 평가 (1-5점).
+
+## 평가 방법
+주관적인 품질 평가 테스트에서 피실험자가 시스템 품질 성능에 대해 미리 정의된 등급(일반적으로 1~5점)으로 의견을 할당한 값의 산술 평균.

--- a/src/content/benchmarks/wer-librispeech-clean.md
+++ b/src/content/benchmarks/wer-librispeech-clean.md
@@ -1,0 +1,17 @@
+---
+benchmarkId: wer-librispeech-clean
+domain: stt
+status: published
+updated: 2026-05-09
+sources:
+  - https://arxiv.org/abs/2212.04356
+paperUrl: https://arxiv.org/abs/2212.04356
+---
+
+# WER (LibriSpeech Clean)
+
+## 개요
+LibriSpeech clean 테스트셋 기준 단어 오류율(Word Error Rate)을 측정하는 벤치마크.
+
+## 평가 방법
+음성 인식 모델이 예측한 텍스트와 실제 텍스트 간의 단어 오류율을 계산.

--- a/src/content/organizations/itu-t.md
+++ b/src/content/organizations/itu-t.md
@@ -1,0 +1,13 @@
+---
+orgId: itu-t
+name: ITU-T
+type: government
+status: draft
+updated: 2026-05-09
+sources:
+  - https://en.wikipedia.org/wiki/ITU-T
+---
+
+# ITU-T
+국제 전기 통신 연합 전기 통신 표준화 부문 (International Telecommunication Union Telecommunication Standardization Sector)
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/journal/2026-05-09-profile-benchmark.md
+++ b/src/data/journal/2026-05-09-profile-benchmark.md
@@ -1,0 +1,19 @@
+---
+date: 2026-05-09
+agent: profile-benchmark
+status: completed
+summary: "STT 및 TTS 벤치마크 2건(wer-librispeech-clean, mos) 상세 페이지 작성"
+---
+
+## Todo
++ [x] wer-librispeech-clean 벤치마크 프로파일 작성
++ [x] mos 벤치마크 프로파일 작성
++ [x] 관련 기관 스텁 작성
+
+## 조사 내역
+## 수행한 작업
+- [x] `wer-librispeech-clean` 벤치마크 작성 ← https://arxiv.org/abs/2212.04356
+- [x] `mos` 벤치마크 작성 ← https://en.wikipedia.org/wiki/Mean_opinion_score
+- [x] `itu-t` 기관 스텁 작성 ← https://en.wikipedia.org/wiki/ITU-T
+## 판단 / 고민
+## 이슈 제기


### PR DESCRIPTION
Adds markdown profiles for `wer-librispeech-clean` and `mos` benchmarks to `src/content/benchmarks/`. Also adds a stub for `itu-t` in `src/content/organizations/` and records progress in the agent's journal.

---
*PR created automatically by Jules for task [18365216468838581333](https://jules.google.com/task/18365216468838581333) started by @GGJJack*