### PR TITLE
feat: generate daily report for 2026-05-08

### DIFF
--- a/src/data/journal/2026-05-09-journal.md
+++ b/src/data/journal/2026-05-09-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-09
+agent: journal
+status: completed
+summary: "2026-05-08 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- [x] 2026-05-08 일자 `collect-llm`, `profile-model`, `reinforce` 저널 읽기
+- [x] `src/data/updates/2026-05-08-daily.md` 데일리 리포트 작성

--- a/src/data/updates/2026-05-08-daily.md
+++ b/src/data/updates/2026-05-08-daily.md
@@ -1,0 +1,28 @@
+---
+date: 2026-05-08
+type: note
+title: 데일리 리포트 · 2026-05-08
+summary: "Gemma 4 등 신규 모델 5건 등록 및 11건 보강, Yi-Lightning 및 Gemma 4 31B Dense 상세 페이지 작성, Mistral 및 국내 모델 메타데이터 보강 시도"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: `gemma-4-31b-dense`, `gemma-4-26b-moe`, `gemma-4-e4b`, `gemma-4-e2b`, `yi-lightning`  ← https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/
+- 보강: `hyperclova-x`, `alphaevolve`, `gpt-5-5-instant`, `solar-pro-3`, `claude-sonnet-4-6`, `glm-4-flash`, `glm-4-9b-chat`  ← memory
+- 보강: `deepseek-v4-flash`, `deepseek-v4-pro`, `devstral-2`  ← https://api-docs.deepseek.com/quick_start/pricing 및 https://docs.mistral.ai/models/
+
+### 벤치마크 (collect-benchmark)
+- (수집 내역 없음)
+
+## 상세 페이지 작성 (profile)
+- models/yi-lightning.md
+- models/gemma-4-31b-dense.md
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 2건
+  - 부분 진행: Mistral Large 3 및 Mistral Medium 3.5 벤치마크 데이터 재조사 및 이슈 업데이트 ← https://mistral.ai/news/mistral-3
+  - 부분 진행: EXAONE 3.0 및 HyperCLOVA X 메타데이터 확인 및 이슈 업데이트
+
+## 미해결 이슈
+- (신규 미해결 이슈 없음)


### PR DESCRIPTION
This PR completes the daily journal task triggered on 2026-05-09 KST 05:00.

1. It reads the agent journals (`collect-llm`, `profile-model`, `reinforce`) from the previous day (2026-05-08).
2. It generates a single daily report `src/data/updates/2026-05-08-daily.md` effectively summarizing the activities (new models collected, profiles written, and issues processed).
3. It creates its own completion log at `src/data/journal/2026-05-09-journal.md`.

---
*PR created automatically by Jules for task [13832840738636562076](https://jules.google.com/task/13832840738636562076) started by @GGJJack*