### PR TITLE
feat: collect benchmark scores for Gemma 4 models

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -470,6 +470,62 @@
         "source": "official",
         "sourceUrl": "https://huggingface.co/01-ai/Yi-1.5-34B-Chat"
       }
+    },
+    "gemma-4-31b-dense": {
+      "mmlu-pro": {
+        "value": 85.2,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      },
+      "gpqa": {
+        "value": 84.3,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      }
+    },
+    "gemma-4-26b-moe": {
+      "mmlu-pro": {
+        "value": 82.6,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      },
+      "gpqa": {
+        "value": 82.3,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      }
+    },
+    "gemma-4-e4b": {
+      "mmlu-pro": {
+        "value": 69.4,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      },
+      "gpqa": {
+        "value": 58.6,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      }
+    },
+    "gemma-4-e2b": {
+      "mmlu-pro": {
+        "value": 60,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      },
+      "gpqa": {
+        "value": 43.4,
+        "date": "2026-05-10",
+        "source": "official",
+        "sourceUrl": "https://ai.google.dev/gemma/docs/core/model_card_4"
+      }
     }
   }
 }

--- a/src/data/journal/2026-05-09-collect-benchmark.md
+++ b/src/data/journal/2026-05-09-collect-benchmark.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-09
+agent: collect-benchmark
+status: completed
+summary: "Gemma 4 모델군 (31B, 26B MoE, E4B, E2B) MMLU-Pro 및 GPQA 벤치마크 점수 수집"
+---
+
+## Todo
+- [x] 신규 등록된 LLM 모델의 벤치마크 점수 매칭
+
+## 조사 내역
+- 01:30  Gemma 4 모델군 (31B, 26B MoE, E4B, E2B) 벤치마크 점수 확인 (MMLU-Pro, GPQA 등)  ← https://ai.google.dev/gemma/docs/core/model_card_4
+
+## 수행한 작업
+- [x] `gemma-4-31b-dense` 점수 등록 (MMLU-Pro 85.2, GPQA 84.3)  ← https://ai.google.dev/gemma/docs/core/model_card_4
+- [x] `gemma-4-26b-moe` 점수 등록 (MMLU-Pro 82.6, GPQA 82.3)  ← https://ai.google.dev/gemma/docs/core/model_card_4
+- [x] `gemma-4-e4b` 점수 등록 (MMLU-Pro 69.4, GPQA 58.6)  ← https://ai.google.dev/gemma/docs/core/model_card_4
+- [x] `gemma-4-e2b` 점수 등록 (MMLU-Pro 60.0, GPQA 43.4)  ← https://ai.google.dev/gemma/docs/core/model_card_4
+
+## 판단 / 고민
+- MMLU-Pro 및 GPQA Diamond 등 제공된 표에서 주요 점수를 추출하여 등록 완료.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
- `collect-benchmark` task executed.
- Extracted benchmark scores from official model cards for `gemma-4-31b-dense`, `gemma-4-26b-moe`, `gemma-4-e4b`, `gemma-4-e2b`.
- Updated `llm.json` with `mmlu-pro` and `gpqa` scores via `benchmark.ts` script.
- Cleaned up temp execution files.
- Documented session summary in journal `src/data/journal/2026-05-09-collect-benchmark.md`.

---
*PR created automatically by Jules for task [5963785154363066256](https://jules.google.com/task/5963785154363066256) started by @GGJJack*