### PR TITLE
feat: add daily report for 2026-05-09 and update journal

### DIFF
--- a/src/data/journal/2026-05-10-journal.md
+++ b/src/data/journal/2026-05-10-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-10
+agent: journal
+status: completed
+summary: "2026-05-09 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- [x] 2026-05-09 일자 `collect-llm`, `collect-benchmark`, `profile-model`, `profile-benchmark`, `reinforce` 저널 읽기
+- [x] `src/data/updates/2026-05-09-daily.md` 데일리 리포트 작성

--- a/src/data/updates/2026-05-09-daily.md
+++ b/src/data/updates/2026-05-09-daily.md
@@ -1,0 +1,33 @@
+---
+date: 2026-05-09
+type: note
+title: 데일리 리포트 · 2026-05-09
+summary: "Gemini Deep Research 등 신규 모델 3건 등록 및 메타데이터 보강, 벤치마크 및 프로파일 6건 작성, 이슈 3건 처리"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: `gemini-deep-research`, `grok-4.1-fast`, `grok-4.20-multi-agent`
+- 보강: `yi-lightning`, `grok-4-20`, `grok-4-3`, `alphaevolve`, `gemma-4` family
+
+### 벤치마크 (collect-benchmark)
+- 보강: `gemma-4-31b-dense`, `gemma-4-26b-moe`, `gemma-4-e4b`, `gemma-4-e2b` (MMLU-Pro 및 GPQA)  ← https://ai.google.dev/gemma/docs/core/model_card_4
+
+## 상세 페이지 작성 (profile)
+- models/gemini-deep-research.md
+- models/grok-4.20-multi-agent.md
+- benchmarks/wer-librispeech-clean.md
+- benchmarks/mos.md
+- benchmarks/wer-fleurs-ko.md
+- organizations/itu-t.md
+
+## 이슈 처리 (reinforce)
+- 해결 2건 / 부분 1건
+  - 해결: Mistral Large 3 (MMLU, GPQA, Chatbot Arena ELO 등록)  ← https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512
+  - 해결: Gemini 3.1 Pro (GPQA 점수 재확인 및 등록)  ← https://llm-stats.com/benchmarks/gpqa
+  - 부분: Mistral Medium 3.5 (HumanEval 점수 미공개 확인 및 이슈 업데이트)  ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5
+
+## 미해결 이슈
+- issues/2026-05-07-collect-llm-metadata-missing.md — `hyperclova-x` (HCX-003), `yi-large`, `baichuan-4`, `sakana-fugu` 시리즈의 2026년 5월 기준 최신 가격 및 상세 사양 확인 불가
+- issues/cer-ksponspeech — 벤치마크 논문 링크 오류로 상세 페이지 생성 취소


### PR DESCRIPTION
Adds the daily report for 2026-05-09 by aggregating activities from `collect-*`, `profile-*`, and `reinforce` journals.
Creates the `journal` task record for today (2026-05-10).

---
*PR created automatically by Jules for task [219400761237792878](https://jules.google.com/task/219400761237792878) started by @GGJJack*