### PR TITLE
Profile CER (KsponSpeech) Benchmark

### DIFF
--- a/src/content/benchmarks/cer-ksponspeech.md
+++ b/src/content/benchmarks/cer-ksponspeech.md
@@ -1,0 +1,22 @@
+---
+benchmarkId: cer-ksponspeech
+domain: stt
+status: draft
+updated: 2026-05-12
+sources:
+  - https://ksp.etri.re.kr/ksp/article/read?id=62525
+organization: etri
+paperUrl: https://dx.doi.org/10.3390/app10196936
+highlights:
+  - "1000시간 분량의 한국어 자발 발화 데이터셋"
+  - "다양한 주제의 2인 자유 대화 녹음"
+---
+
+# CER (KsponSpeech)
+
+## 개요
+한국어 자발 발화 데이터셋의 음절 오류율(CER) 측정용 벤치마크. ETRI에서 구축한 약 1,000시간 분량의 일반 공개 도메인 대화 음성 코퍼스(KsponSpeech)를 사용한다.
+
+## 평가 데이터 특징
+데이터는 2,000여 명의 한국어 원어민이 조용한 환경에서 다양한 주제에 대해 자유롭게 대화하는 내용을 녹음하고 수동으로 전사하여 구축되었다.
+전사 내용은 정서법과 발음법으로 이중 구성되어 있으며 간투어, 반복어, 불완전어 등 자발 발화에서 나타나는 비유창성 태그를 포함한다.

--- a/src/content/organizations/etri.md
+++ b/src/content/organizations/etri.md
@@ -1,0 +1,12 @@
+---
+orgId: etri
+name: ETRI
+type: government
+status: draft
+updated: 2026-05-12
+sources:
+  - https://ksp.etri.re.kr/ksp/article/read?id=62525
+---
+
+# ETRI (Electronics and Telecommunications Research Institute)
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-05-12-profile-benchmark-etri.md
+++ b/src/data/issues/2026-05-12-profile-benchmark-etri.md
@@ -1,0 +1,11 @@
+---
+created: 2026-05-12
+agent: profile-benchmark
+severity: minor
+target: etri
+---
+
+## 상황  `src/content/organizations/etri.md` 기관 상세 조사 필요
+## 시도한 것  스텁 파일 생성 완료
+## 요청  기관 상세 조사 필요
+## 진행 내역

--- a/src/data/journal/2026-05-11-profile-benchmark.md
+++ b/src/data/journal/2026-05-11-profile-benchmark.md
@@ -1,0 +1,17 @@
+---
+date: 2026-05-11
+agent: profile-benchmark
+status: completed
+summary: "작성: cer-ksponspeech"
+---
+
+## Todo
+## 조사 내역
+- 18:16 CER (KsponSpeech) 논문 검색 결과 확인 ← https://ksp.etri.re.kr/ksp/article/read?id=62525
+## 수행한 작업
+- [x] `src/content/benchmarks/cer-ksponspeech.md` 작성 완료 ← https://dx.doi.org/10.3390/app10196936
+- [x] `src/content/organizations/etri.md` 스텁 생성 완료
+## 판단 / 고민
+- 이전에 잘못된 논문을 기반으로 생성했던 파일을 삭제하고 수정된 파일을 생성함. KsponSpeech는 ETRI에서 발행하였으므로 ETRI 스텁도 같이 생성하였음.
+## 이슈 제기
+- issues/2026-05-12-profile-benchmark-etri.md


### PR DESCRIPTION
This PR handles the daily `profile-benchmark` task by targeting the missing `cer-ksponspeech` benchmark. 
- Investigated and corrected the KsponSpeech paper URL to extract relevant details about the benchmark and dataset.
- Added a markdown file for the benchmark under `src/content/benchmarks/`.
- Generated a stub for the benchmark author, ETRI, under `src/content/organizations/`.
- Raised a minor issue to fill in the ETRI organization details in a future session.
- Appended task log to `src/data/journal/2026-05-11-profile-benchmark.md`.

---
*PR created automatically by Jules for task [8991866445382070578](https://jules.google.com/task/8991866445382070578) started by @GGJJack*