### PR TITLE
feat: collect and match benchmarks for new LLMs (Gemma 3)

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -887,6 +887,20 @@
         "source": "community",
         "sourceUrl": "https://llmbase.ai/compare/gemini-3-1-flash-lite-preview,gemini-3-flash/"
       }
+    },
+    "gemma-3-27b": {
+      "mmlu-pro": {
+        "value": 67.5,
+        "date": "2026-05-13",
+        "source": "official",
+        "sourceUrl": "https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights"
+      },
+      "gpqa": {
+        "value": 42.4,
+        "date": "2026-05-13",
+        "source": "official",
+        "sourceUrl": "https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights"
+      }
     }
   }
 }

--- a/src/data/issues/2026-05-14-collect-benchmark-unverified.md
+++ b/src/data/issues/2026-05-14-collect-benchmark-unverified.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-14
+agent: collect-benchmark
+severity: minor
+target: llm/qwen-3-235b,deepseek-v3-2,llama-4-maverick-17b,llama-4-scout-17b
+---
+
+## 상황
+최근 수집된 신규 모델들(Qwen3 235B, DeepSeek V3.2, Llama 4 계열)에 대해 벤치마크 공식 출처 점수를 명확히 찾기 어려움.
+
+## 시도한 것
+Google Search를 통해 해당 모델들의 주요 벤치마크(MMLU-Pro, GPQA 등) 점수를 탐색했으나 공식 출처나 재현 가능한 검증된 점수 확보 실패.
+
+## 요청
+해당 모델들의 공식 기술 문서 및 리더보드 점수 발표가 확인되면 벤치마크 점수 등록 필요.

--- a/src/data/journal/2026-05-13-collect-benchmark.md
+++ b/src/data/journal/2026-05-13-collect-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-05-13
+agent: collect-benchmark
+status: completed
+summary: "점수 매칭 (Gemma 3 27B 등 최근 추가된 모델 중심)"
+---
+
+## Todo
+- [x] 신규 추가된 LLM 모델(Gemma 3 27B 등)의 점수 매칭
+
+## 조사 내역
+- 01:30  gemma-3-27b 공식 점수 수집 (MMLU-Pro 67.5, GPQA 42.4) ← https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights
+
+## 수행한 작업
+- [x] `gemma-3-27b` 점수 등록 (MMLU-Pro 67.5, GPQA 42.4) ← https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights
+
+## 판단 / 고민
+- Qwen3 235B, DeepSeek V3.2 등 일부 최신 추가 모델은 아직 구체적인 점수 출처를 명확히 찾기 어려워 패스하고 이슈 티켓으로 등록함.
+
+## 이슈 제기
+- issues/2026-05-14-collect-benchmark-unverified.md


### PR DESCRIPTION
## Summary
- Initialized the `collect-benchmark` journal for May 13, 2026.
- Collected and matched verified official benchmark scores for the newly added `gemma-3-27b` model (MMLU-Pro: 67.5, GPQA: 42.4).
- Created an issue ticket (`src/data/issues/2026-05-14-collect-benchmark-unverified.md`) to track other recent models (Qwen3 235B, DeepSeek V3.2, Llama 4 Maverick/Scout) whose official benchmark scores could not be verified from the initial sources.
- Adhered strictly to using the `benchmark.ts` script for modifying JSON files and avoided any manual JSON edits.

---
*PR created automatically by Jules for task [1868519517565655256](https://jules.google.com/task/1868519517565655256) started by @GGJJack*