### PR TITLE
Add profiles for Gemma 3 12B and Qwen3-235B

### DIFF
--- a/src/content/models/gemma-3-12b.md
+++ b/src/content/models/gemma-3-12b.md
@@ -1,0 +1,31 @@
+---
+modelId: gemma-3-12b
+domain: llm
+status: published
+updated: 2026-05-13
+sources:
+  - https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights
+  - https://aws.amazon.com/bedrock/pricing/
+features:
+  toolUse: true
+  vision: true
+highlights:
+  - "Google DeepMind의 3세대 오픈 모델 제품군 중 중간급 모델"
+  - "12B 파라미터 규모로 효율성과 성능의 균형 최적화"
+  - "Gemma 2 27B 수준의 성능을 더 적은 자원으로 구현"
+relatedOrganization: google-research
+---
+
+# Gemma 3 12B 소개
+
+## 개요
+Gemma 3 12B는 Google DeepMind가 2025년 3월에 발표한 차세대 오픈 가중치(Open-weights) 모델입니다. Google의 플래그십 모델인 Gemini의 기술력을 바탕으로 설계되었으며, 1B, 4B, 27B와 함께 출시된 Gemma 3 라인업 중 성능과 자원 효율성 사이의 최적의 균형을 제공하는 모델입니다. 특히 12B 모델은 이전 세대의 훨씬 큰 모델인 Gemma 2 27B와 대등하거나 이를 능가하는 지능을 보유하면서도, 더 적은 계산 자원으로 구동이 가능하다는 점이 특징입니다.
+
+## 기술 특징
+Gemma 3 12B는 텍스트뿐만 아니라 이미지와 비디오 입력을 처리할 수 있는 네이티브 시각-언어 모델(Vision-Language Model)입니다. 아키텍처 측면에서는 메모리 효율을 위해 로컬 어텐션(Local Attention)과 글로벌 어텐션(Global Attention)을 교차로 사용하는 구조를 채택했습니다. 또한, 지식 증류(Knowledge Distillation) 기법을 통해 상위 모델의 지능을 효과적으로 학습했으며, 강화학습(RLHF, RLEF 등)을 통해 수학적 추론과 코딩 능력을 대폭 강화했습니다. 128K 토큰의 확장된 컨텍스트 윈도우를 지원하여 긴 문서나 복잡한 시각 정보를 처리하는 데 적합합니다.
+
+## 사용 사례
+이 모델은 중간 규모의 서버나 고사양 소비자 하드웨어에서 원활하게 구동될 수 있어, 기업용 지식 베이스 분석, 고성능 코딩 어시스턴트, 그리고 시각 정보가 포함된 멀티모달 에이전트 구축에 널리 활용됩니다. 특히 수학과 코딩 분야에서 강력한 성능을 보여주며, 도구 사용(Tool Use) 및 함수 호출 기능이 강화되어 외부 시스템과 상호작용하는 복잡한 워크플로우를 자동화하는 데 최적화되어 있습니다.
+
+## 한계
+Gemma 3 12B는 강력한 성능을 보여주지만, 텍스트 전용인 1B 모델과 달리 시각 인코더(SigLIP)를 포함하고 있어 구동 시 일정한 VRAM 용량이 필수적입니다. 또한, 오픈 가중치 모델로서 특정 사용 환경에 따른 미세 조정이 가능하지만, Google의 공식 상용 API 모델인 Gemini 1.5 Pro 등에 비해서는 전반적인 지식의 폭이나 복잡한 추론의 정교함에서 차이가 있을 수 있습니다. 모든 AI 모델과 마찬가지로 사실 관계가 틀린 내용을 생성하는 환각 현상이 발생할 수 있으므로 결과물에 대한 검증이 권장됩니다.

--- a/src/content/models/qwen-3-235b.md
+++ b/src/content/models/qwen-3-235b.md
@@ -1,0 +1,31 @@
+---
+modelId: qwen-3-235b
+domain: llm
+status: published
+updated: 2026-05-13
+sources:
+  - https://qwenlm.github.io/blog/qwen3/
+  - https://aws.amazon.com/bedrock/pricing/
+features:
+  toolUse: true
+  extendedThinking: true
+highlights:
+  - "Qwen3 제품군의 최상위 MoE 모델 (235B 파라미터)"
+  - "활성 파라미터 22B로 효율적인 고성능 추론 실현"
+  - "생각 모드(Thinking Mode) 지원으로 복잡한 추론 문제 해결"
+relatedOrganization: alibaba
+---
+
+# Qwen3-235B 소개
+
+## 개요
+Qwen3-235B(Qwen3-235B-A22B)는 Alibaba Cloud가 2025년 4월에 발표한 Qwen 제품군의 최신 플래그십 대규모 언어 모델입니다. 총 2350억 개의 파라미터를 보유한 혼합 전문가(Mixture-of-Experts, MoE) 아키텍처를 채택하고 있으며, 추론 시에는 이 중 220억 개의 파라미터만 활성화하여 계산 효율성을 극대화했습니다. 이 모델은 코딩, 수학 및 일반적인 지능 평가에서 DeepSeek-R1, o1, Gemini 2.5 Pro와 같은 최상위권 모델들과 경쟁할 수 있는 성능을 목표로 설계되었습니다.
+
+## 기술 특징
+Qwen3-235B의 가장 혁신적인 특징은 '하이브리드 사고 모드(Hybrid Thinking Modes)'의 도입입니다. 사용자는 복잡한 문제 해결을 위해 모델이 단계별 추론을 수행하는 '생각 모드(Thinking Mode)'와 빠른 응답을 제공하는 '비생각 모드(Non-Thinking Mode)' 중 선택할 수 있습니다. 이는 추론 예산(Inference Budget)을 유연하게 제어할 수 있게 하여, 비용 효율성과 성능 사이의 최적점을 찾도록 돕습니다. 또한, 약 36조 개의 토큰과 119개 이상의 언어 및 방언을 학습하여 강력한 다국어 능력을 보유하고 있으며, 128K 토큰의 컨텍스트 윈도우를 지원합니다.
+
+## 사용 사례
+Qwen3-235B는 최상위 수준의 코딩 능력과 수학적 추론 능력이 요구되는 복잡한 문제 해결에 최적화되어 있습니다. 강화된 도구 사용(Tool Calling) 및 MCP(Model Context Protocol) 지원을 통해 고도로 정교한 AI 에이전트 구축이 가능하며, 기업의 대규모 데이터 분석 및 다국어 비즈니스 환경에서의 커뮤니케이션 도구로 활용됩니다. 오픈 가중치 모델로서 연구자들과 개발자들이 자유롭게 성능을 검증하고 특정 도메인에 맞춰 최적화할 수 있다는 점이 큰 장점입니다.
+
+## 한계
+총 파라미터 규모가 235B에 달하기 때문에, MoE 구조로 인해 추론 시의 계산 부담은 낮지만 모델을 로드하기 위해서는 상당한 수준의 VRAM 자원이 필요합니다. 또한 '생각 모드'를 사용할 경우 답변의 정확도는 높아지지만 그만큼 응답 생성 시간이 길어질 수 있다는 점을 고려해야 합니다. Alibaba Cloud는 지속적인 업데이트를 통해 성능을 개선하고 있으나, 특정 전문 분야에서의 미세한 뉘앙스 처리나 최신 시사 정보 반영에는 한계가 있을 수 있습니다.

--- a/src/data/journal/2026-05-13-profile-model.md
+++ b/src/data/journal/2026-05-13-profile-model.md
@@ -1,0 +1,28 @@
+---
+date: 2026-05-13
+agent: profile-model
+status: completed
+summary: "Gemma 3 12B 및 Qwen3-235B 상세 프로필 작성 완료"
+---
+
+## Todo
+- [x] Gemma 3 12B 프로필 작성
+- [x] Qwen3-235B 프로필 작성
+
+## 조사 내역
+- 02:00 작업 시작.
+- 02:01 대상 선정: gemma-3-12b, qwen-3-235b (최근 collect-llm 등록 및 보강 대상)
+- 19:02 Gemma 3 조사: 2025년 3월 발표, 시각-언어 모델(4B, 12B, 27B), SigLIP 인코더 사용, 128k 컨텍스트. ← https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights
+- 19:08 Qwen3 조사: 2025년 4월 발표, 235B MoE (22B 활성), 하이브리드 사고 모드(Thinking Mode) 지원, 36T 토큰 학습. ← https://qwenlm.github.io/blog/qwen3/
+
+## 수행한 작업
+- [x] `src/content/models/gemma-3-12b.md` 생성 및 상세 내용 작성 (published) ← https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights
+- [x] `src/content/models/qwen-3-235b.md` 생성 및 상세 내용 작성 (published) ← https://qwenlm.github.io/blog/qwen3/
+- [x] `bun run build`를 통한 Zod 스키마 및 빌드 검증 완료.
+
+## 판단 / 고민
+- Gemma 3의 정확한 발표 시점에 대해 기사마다 차이가 있으나, 가장 상세한 deeplearning.ai 기사(2025-03-26)를 기준으로 작성함. (registry에는 2026-05-11로 되어 있으나, profile에서는 기사 근거 사용)
+- Qwen3-235B는 'Thinking mode'가 핵심 차별점이므로 `extendedThinking: true` 피처를 명시함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Created new model profile pages for Google's Gemma 3 12B and Alibaba's Qwen3-235B. Gemma 3 12B is documented as a multimodal dense model with SigLIP encoder, while Qwen3-235B is documented as a high-performance MoE model featuring a unique Thinking Mode. Both profiles include technical specifications, use cases, and limitations based on official announcements. Updated the daily journal to reflect the work performed.

Fixes #179

---
*PR created automatically by Jules for task [4018694799679614777](https://jules.google.com/task/4018694799679614777) started by @GGJJack*