### PR TITLE
feat(journal): daily report for 2026-05-14

### DIFF
--- a/src/data/journal/2026-05-15-journal.md
+++ b/src/data/journal/2026-05-15-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-15
+agent: journal
+status: completed
+summary: "전일(2026-05-14) 에이전트 수행 로그 취합 및 데일리 리포트 발행"
+---
+
+## 수행한 작업
+- [x] 2026-05-14 일자 profile-model, profile-benchmark 저널 파싱 및 취합
+- [x] `src/data/updates/2026-05-14-daily.md` 데일리 리포트 발행

--- a/src/data/updates/2026-05-14-daily.md
+++ b/src/data/updates/2026-05-14-daily.md
@@ -1,0 +1,16 @@
+---
+date: 2026-05-14
+type: note
+title: 데일리 리포트 · 2026-05-14
+summary: "DeepSeek-V3.2, GLM-5 상세 프로파일 작성 및 Arena Hard v2, SWE-bench Pro 벤치마크 상세 페이지 작성 완료"
+---
+
+## 상세 페이지 작성 (profile)
+- `src/content/benchmarks/arena-hard-v2.md` 작성 (draft, org: lmsys) ← https://github.com/lm-sys/arena-hard-v2
+- `src/content/benchmarks/swe-bench-pro.md` 작성 (draft, org: scale-ai) ← https://labs.scale.com/papers/swe_bench_pro
+- `src/content/organizations/scale-ai.md` 스텁 생성 (draft) ← https://labs.scale.com/
+- `src/content/models/deepseek-v3.2.md` 작성
+- `src/content/models/glm-5.md` 작성
+
+## 미해결 이슈
+- issues/2026-05-15-profile-benchmark-scale-ai.md


### PR DESCRIPTION
Compiled yesterday's (2026-05-14) `profile-benchmark` and `profile-model` journals into a summarized daily report at `src/data/updates/2026-05-14-daily.md` following the template in `skills/journal/SKILL.md`. Recorded the completion of this task in `src/data/journal/2026-05-15-journal.md`.

---
*PR created automatically by Jules for task [10521490600658578127](https://jules.google.com/task/10521490600658578127) started by @GGJJack*