### PR TITLE
chore: create issue tickets for unverified benchmark scores

### DIFF
--- a/src/data/issues/2026-05-15-collect-benchmark-unverified.md
+++ b/src/data/issues/2026-05-15-collect-benchmark-unverified.md
@@ -1,0 +1,22 @@
+---
+created: 2026-05-15
+agent: collect-benchmark
+severity: minor
+target: llm/unverified-scores
+---
+
+## 상황
+다음 모델들에 대한 MMLU, MMLU-Pro, GPQA 벤치마크 점수의 신뢰할 수 있는 공식 출처를 찾지 못함:
+- Kimi K2.5 (`kimi-k2.5`)
+- Qwen3-30B-A3B (`qwen-3-30b-a3b`)
+- Gemma 3 4B (`gemma-3-4b`)
+- Gemma 3 12B (`gemma-3-12b`)
+- NVIDIA Nemotron 3 Nano (`nvidia-nemotron-3-nano`)
+
+## 시도한 것
+- Google 검색을 통해 해당 모델명과 MMLU, GPQA 벤치마크 점수를 검색함
+- 허깅페이스 및 제조사 공식 블로그/기술 문서 페이지 등을 확인하였으나 명확하고 신뢰할 수 있는 수치를 찾지 못했거나 점수 정보가 포함된 페이지를 찾을 수 없었음.
+- 출처 URL 없는 필드는 저장하지 않는 규칙에 따라 JSON 파일에 기록하지 않고 패스함.
+
+## 요청
+- 향후 해당 모델들의 공식 성능 지표 발표 또는 신뢰할 수 있는 리더보드 등재 시 점수 수집 및 반영 요망

--- a/src/data/journal/2026-05-15-collect-benchmark.md
+++ b/src/data/journal/2026-05-15-collect-benchmark.md
@@ -1,0 +1,25 @@
+---
+date: 2026-05-15
+agent: collect-benchmark
+status: completed
+summary: "신규 추가된 모델들의 벤치마크 점수 출처 확인 실패에 따른 이슈 티켓 발행"
+---
+
+## Todo
+- [x] 신규 추가된 LLM 모델(Kimi K2.5, Qwen3-30B-A3B, Gemma 3 4B/12B, NVIDIA Nemotron 3 Nano)의 점수 매칭
+
+## 조사 내역
+- 01:30 Kimi K2.5 벤치마크 점수 검색 시도 (명확한 수치/출처 확인 실패)
+- 01:32 Qwen3-30B-A3B 벤치마크 점수 검색 시도 (명확한 수치/출처 확인 실패)
+- 01:34 Gemma 3 4B/12B 벤치마크 점수 검색 시도 (명확한 수치/출처 확인 실패)
+- 01:36 NVIDIA Nemotron 3 Nano 벤치마크 점수 검색 시도 (명확한 수치/출처 확인 실패)
+
+## 수행한 작업
+- [x] 출처 불분명 데이터 미기재 정책에 따라 점수 업데이트 생략 및 관련 이슈 티켓 생성
+
+## 판단 / 고민
+- 검색된 결과물들이 서드파티 리뷰 혹은 부정확한 출처에 기반한 것으로 판단되어 벤치마크 점수 업데이트를 하지 않기로 함.
+- 대신 `src/data/issues/2026-05-15-collect-benchmark-unverified.md` 티켓을 생성하여 추후 보강을 요청함.
+
+## 이슈 제기
+- issues/2026-05-15-collect-benchmark-unverified.md


### PR DESCRIPTION
This PR handles the daily `collect-benchmark` task for LLMs. 

During the search, the required benchmark scores (MMLU, MMLU-Pro, GPQA) could not be definitively found via official and reliable sources for the newly added models (Kimi K2.5, Qwen3-30B-A3B, Gemma 3 4B, Gemma 3 12B, NVIDIA Nemotron 3 Nano). In accordance with the project's strict sourcing guidelines, these scores were not added to the JSON data file.

Instead, an issue ticket (`src/data/issues/2026-05-15-collect-benchmark-unverified.md`) was created to track these missing scores for future updates. A journal entry was also created to log the daily run and findings.

---
*PR created automatically by Jules for task [15246388171327056447](https://jules.google.com/task/15246388171327056447) started by @GGJJack*