### PR TITLE
Add profile pages for Llama 4 Scout 17B and EEVE-Korean-10.8B

### DIFF
--- a/src/content/models/eeve-korean-10.8b.md
+++ b/src/content/models/eeve-korean-10.8b.md
@@ -1,0 +1,32 @@
+---
+modelId: eeve-korean-10.8b
+domain: llm
+status: published
+updated: 2026-05-15
+sources:
+  - https://huggingface.co/yanolja/EEVE-Korean-10.8B-v1.0
+  - https://arxiv.org/abs/2402.14714
+  - https://github.com/yanolja/EEVE-Korean
+features:
+  toolUse: false
+  vision: false
+highlights:
+  - "Upstage SOLAR-10.7B를 기반으로 한 한국어 어휘 확장 모델"
+  - "8,960개의 한국어 토큰 추가 및 효율적인 7단계 학습 기법 적용"
+  - "Apache-2.0 라이선스로 상업적 이용 및 수정이 자유로움"
+relatedOrganization: yanolja
+---
+
+# EEVE-Korean-10.8B 소개
+
+## 개요
+EEVE-Korean-10.8B는 야놀자(Yanolja)의 NEXT LLM 팀이 2024년 2월에 공개한 한국어 특화 대규모 언어 모델입니다. 이 모델은 Upstage의 SOLAR-10.7B-v1.0을 베이스 모델로 하여, 영어 중심의 기존 모델을 한국어 환경에 맞게 효율적으로 적응시킨 것이 특징입니다. 특히 한국어 웹 데이터와 정밀하게 선정된 어휘를 바탕으로 사전 학습되어, 한국어의 문맥 이해와 생성 능력에서 우수한 성능을 보여줍니다.
+
+## 기술 특징
+이 모델의 핵심 기술은 '효율적이고 효과적인 어휘 확장(Efficient and Effective Vocabulary Expansion)' 방식입니다. 연구진은 한국어 웹 코퍼스에서 빈도가 높은 8,960개의 한국어 토큰을 엄선하여 기존 토크나이저에 추가했습니다. 학습 과정에서는 매개변수 동결(Parameter Freezing)을 포함한 7단계의 점진적 학습 기법을 도입하여, 입력 임베딩부터 전체 파라미터에 이르기까지 순차적으로 최적화했습니다. 이를 통해 베이스 모델이 가진 영어 추론 능력은 보존하면서도 한국어 처리 효율과 품질을 획기적으로 높였습니다.
+
+## 사용 사례
+EEVE-Korean-10.8B는 한국어 텍스트 생성, 요약, 문단 분류 등 다양한 자연어 처리 작업에 적합합니다. 특히 오픈 소스 기반의 Apache-2.0 라이선스를 채택하고 있어, 기업들이 내부 인프라에 구축하여 보안이 중요한 한국어 챗봇 서비스를 운영하거나 특정 도메인에 맞게 미세 조정(Fine-tuning)하여 사용하기에 용이합니다. 또한 모델 크기가 10.8B 수준으로 비교적 작아 소비자용 GPU에서도 구동이 가능하다는 장점이 있습니다.
+
+## 한계
+이 모델은 지시어 기반 미세 조정(Instruction Fine-tuning)이 적용되지 않은 베이스 모델(v1.0 기준)이므로, 사용자의 질문에 직접 답하는 대화형 서비스를 구현하기 위해서는 추가적인 인스트럭션 튜닝이나 RLHF 과정이 권장됩니다. 또한 베이스 모델인 SOLAR의 특성을 계승하므로, 컨텍스트 윈도우의 크기나 특정 복잡한 논리 추론 작업에서 최신 초거대 모델들과 비교했을 때 상대적인 성능 차이가 존재할 수 있습니다.

--- a/src/content/models/llama-4-scout-17b.md
+++ b/src/content/models/llama-4-scout-17b.md
@@ -1,0 +1,32 @@
+---
+modelId: llama-4-scout-17b
+domain: llm
+status: published
+updated: 2026-05-15
+sources:
+  - https://aws.amazon.com/bedrock/meta/
+  - https://aws.amazon.com/blogs/aws/llama-4-models-from-meta-now-available-in-amazon-bedrock-serverless
+  - https://aws.amazon.com/machine-learning/llama/
+features:
+  toolUse: true
+  vision: true
+highlights:
+  - "Llama 4 제품군의 고성능 범용 멀티모달 모델"
+  - "16명의 전문가(Experts)를 활용한 Mixture-of-Experts(MoE) 아키텍처"
+  - "업계 최고 수준의 350만(3.5M) 토큰 컨텍스트 윈도우 지원"
+relatedOrganization: meta
+---
+
+# Llama 4 Scout 17B 소개
+
+## 개요
+Llama 4 Scout 17B는 Meta가 2026년 4월에 공개한 Llama 4 시리즈의 범용 멀티모달 모델입니다. Scout 라인업은 이전 세대의 모든 Llama 모델을 능가하는 성능을 제공하면서도, 효율적인 연산을 통해 다양한 산업군에서 활용될 수 있도록 설계되었습니다. 특히 텍스트와 시각 데이터를 동시에 처리할 수 있는 네이티브 멀티모달 능력을 갖추고 있어, 복잡한 비즈니스 워크플로우와 지능형 에이전트 구축에 최적화되어 있습니다.
+
+## 기술 특징
+이 모델은 16명의 전문가를 포함하는 혼합 전문가(Mixture-of-Experts, MoE) 아키텍처를 채택하고 있습니다. 활성 파라미터는 17B 규모이지만 전체 파라미터는 109B에 달하여, 연산 효율성을 유지하면서도 방대한 지식과 추론 능력을 확보했습니다. 가장 주목할 만한 특징은 Amazon Bedrock 기준 350만(3.5M) 토큰에 달하는 압도적인 컨텍스트 윈도우입니다. 이는 수만 페이지의 문서나 대규모 코드 베이스를 한 번에 분석할 수 있게 하며, '얼리 퓨전(Early Fusion)' 기술을 통해 이미지와 텍스트 간의 정밀한 정렬과 추론을 가능하게 합니다.
+
+## 사용 사례
+Llama 4 Scout 17B는 대규모 문서 분석 및 코드 인텔리전스 분야에서 강력한 성능을 발휘합니다. 기업용 지능형 에이전트는 이 모델을 통해 방대한 내부 지식을 참조하여 도구와 워크플로우를 가로지르는 복잡한 추론을 수행할 수 있습니다. 또한 스크린샷이나 사진을 포함한 고객 지원 요청을 실시간으로 분석하거나, 다국어 지원 능력을 바탕으로 전 세계 사용자를 대상으로 한 시각 보조 챗봇 및 콘텐츠 생성 서비스에도 적합합니다.
+
+## 한계
+350만 토큰의 방대한 컨텍스트를 지원하지만, 매우 긴 입력값에 대해 모든 세부 정보를 완벽하게 기억하고 추론하는 '바늘 찾기(Needle In A Haystack)' 성능의 한계는 대규모 데이터 처리 시 고려해야 할 요소입니다. 또한 이미지 처리 능력은 뛰어나지만 실시간 고해상도 비디오 프레임의 연속적인 분석이나 전문적인 의료/법률 이미지 진단과 같은 특화된 영역에서는 추가적인 미세 조정(Fine-tuning)이나 검증이 필요할 수 있습니다.

--- a/src/data/journal/2026-05-15-profile-model.md
+++ b/src/data/journal/2026-05-15-profile-model.md
@@ -1,0 +1,14 @@
+# 2026-05-15 모델 프로파일 작업
+
+## 작업 대상
+1. `llama-4-scout-17b` (Llama 4 Scout 17B)
+2. `eeve-korean-10.8b` (EEVE-Korean-10.8B)
+
+## 상태
+- [x] `llama-4-scout-17b` 상세 페이지 작성
+- [x] `eeve-korean-10.8b` 상세 페이지 작성
+- [x] 빌드 및 스키마 검증 (status: completed)
+
+작성된 파일 경로:
+- `src/content/models/llama-4-scout-17b.md`
+- `src/content/models/eeve-korean-10.8b.md`


### PR DESCRIPTION
This PR adds detailed profile pages for two AI models: Llama 4 Scout 17B and EEVE-Korean-10.8B. The content is based on the latest technical specifications (May 2026) and includes information on architecture, context windows, and training methodologies. The changes have been verified through local builds and visual inspection.

Fixes #197

---
*PR created automatically by Jules for task [4554547119841159228](https://jules.google.com/task/4554547119841159228) started by @GGJJack*