### PR TITLE
feat: profile OSWorld-Verified and Toolathlon benchmarks

### DIFF
--- a/src/content/benchmarks/osworld-verified.md
+++ b/src/content/benchmarks/osworld-verified.md
@@ -1,0 +1,28 @@
+---
+benchmarkId: osworld-verified
+domain: llm
+status: draft
+updated: 2026-05-15
+sources:
+  - "https://os-world.github.io/"
+  - "https://arxiv.org/abs/2404.07972"
+paperUrl: "https://arxiv.org/abs/2404.07972"
+highlights:
+  - "Ubuntu, Windows, macOS 등 실제 컴퓨터 환경에서 멀티모달 에이전트의 워크플로우를 테스트"
+  - "웹 및 데스크탑 앱, 파일 I/O 등을 포함한 369개의 실제 컴퓨터 작업"
+  - "AWS 지원 등을 통한 평가 시간 단축 및 신뢰성 향상을 거친 Verified 버전"
+---
+
+# OSWorld-Verified
+
+## 개요
+OSWorld는 운영체제(Ubuntu, Windows, macOS 등) 환경에서 실제 컴퓨터 작업에 대한 멀티모달 에이전트(Multimodal Agents)의 성능을 평가하기 위한 벤치마크입니다. 단순한 기능 확인이 아니라, 웹과 데스크탑 앱, 파일 I/O 및 여러 애플리케이션에 걸친 워크플로우를 테스트합니다.
+
+OSWorld-Verified는 기존 OSWorld를 기반으로 커뮤니티 보고 문제를 수정하고 AWS 지원 등을 통해 평가 속도와 안정성을 대폭 개선한 업그레이드 버전입니다.
+
+## 평가 방법
+369개의 실사용 환경 기반 작업을 통해 평가를 진행합니다. 각 작업은 세부적인 초기 상태 구성을 포함하고 있으며, 자체 실행 기반 평가 스크립트(execution-based evaluation script)를 사용하여 신뢰할 수 있고 재현 가능한 평가를 수행합니다. 성공적으로 작업을 완료한 비율(%)이 주요 지표가 됩니다.
+
+## 의의 및 한계
+실제 사용자가 매일 접하는 오픈엔디드(open-ended) 컴퓨터 작업을 에이전트가 얼마나 잘 수행할 수 있는지 평가한다는 점에서 실용적인 가치가 높습니다. 초기 버전 이후 발견된 불안정성과 설정 문제를 적극적으로 해결하여(Verified 업데이트) 벤치마크로서의 신뢰성을 높였습니다.
+단, 일부 작업(예: 구글 드라이브 연동 등)은 네트워크 상황이나 인증 등 외부 요인에 의해 설정에 변수가 생길 수 있습니다.

--- a/src/content/benchmarks/toolathlon.md
+++ b/src/content/benchmarks/toolathlon.md
@@ -1,0 +1,26 @@
+---
+benchmarkId: toolathlon
+domain: llm
+status: draft
+updated: 2026-05-15
+sources:
+  - "https://github.com/hkust-nlp/Toolathlon"
+  - "https://arxiv.org/abs/2510.25726"
+organization: hkust-nlp
+paperUrl: "https://arxiv.org/abs/2510.25726"
+highlights:
+  - "현실 환경에서 600개 이상의 다양한 도구(tools)를 사용하는 능력을 평가"
+  - "이메일, 캘린더 관리, 데이터베이스 모니터링 등 복잡하고 다단계의 장기(long-horizon) 워크플로우를 테스트"
+  - "108개의 수작업 또는 큐레이션된 태스크와 Model Context Protocol(MCP) 서버 기반의 도구들을 포함"
+---
+
+# Toolathlon
+
+## 개요
+Toolathlon(Tool Decathlon)은 언어 에이전트(Language Agents)가 다양하고 현실적이며 긴 수행 과정(long-horizon)을 요구하는 태스크를 얼마나 잘 수행하는지 평가하기 위한 벤치마크입니다. 단순화된 태스크나 제한된 도메인을 넘어서, 일상적인 플랫폼(Google Calendar, Notion 등)부터 전문적인 소프트웨어(WooCommerce, Kubernetes, BigQuery 등)까지 아우르는 32개의 소프트웨어 애플리케이션과 604개의 도구를 포함합니다.
+
+## 평가 방법
+평가에는 108개의 태스크가 포함되며, 태스크를 완료하기 위해 에이전트는 평균 약 20회의 턴에 걸쳐 여러 앱과 도구들을 상호작용해야 합니다. 초기 환경 상태는 실제 소프트웨어 환경(예: 수십 명의 학생이 등록된 Canvas 강좌, 실제 재무 스프레드시트 등)을 반영하여 다양하게 설정됩니다. 각 태스크는 전용 평가 스크립트를 통해 엄격하게 검증 및 채점됩니다. (성공률 % 측정)
+
+## 의의 및 한계
+기존의 도구 사용(tool use) 벤치마크들이 제한된 환경의 짧은 상호작용만을 평가했다면, Toolathlon은 실제 복잡한 워크플로우에서 모델이 여러 도구를 결합해 장기적인 목표를 달성할 수 있는지를 평가합니다. 이를 통해 현재 최고 수준(SOTA)의 모델들조차 실세계의 복잡한 태스크에서는 아직 낮은 성공률을 보인다는 점을 입증하고 향후 연구의 지향점을 제시합니다.

--- a/src/content/organizations/hkust-nlp.md
+++ b/src/content/organizations/hkust-nlp.md
@@ -1,0 +1,13 @@
+---
+orgId: hkust-nlp
+name: HKUST NLP
+type: academic
+status: draft
+updated: 2026-05-15
+sources:
+  - "https://github.com/hkust-nlp"
+---
+
+# HKUST NLP
+
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-05-16-profile-benchmark-hkust-nlp.md
+++ b/src/data/issues/2026-05-16-profile-benchmark-hkust-nlp.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-16
+agent: profile-benchmark
+severity: minor
+target: organizations/hkust-nlp
+---
+
+## 상황
+Toolathlon 벤치마크 작성을 위해 `hkust-nlp` (HKUST NLP) 기관 스텁(stub)을 생성했습니다. 현재 스텁 문서에 상세 개요나 부가 정보가 부족한 상태(`status: draft`)입니다.
+
+## 시도한 것
+기본 정보(orgId, name, type, sources)만 포함하여 `src/content/organizations/hkust-nlp.md` 파일을 임시로 작성했습니다.
+
+## 요청
+해당 연구 그룹(HKUST NLP)의 공식 웹사이트, 소속 기관 세부 정보, 주요 연구 방향 등 기관 상세 조사를 수행하여 `src/content/organizations/hkust-nlp.md`의 본문과 메타데이터를 보강해 주시기 바랍니다.

--- a/src/data/issues/2026-05-16-profile-benchmark-osworld-verified-org.md
+++ b/src/data/issues/2026-05-16-profile-benchmark-osworld-verified-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-16
+agent: profile-benchmark
+severity: minor
+target: llm/osworld-verified
+---
+
+## 상황
+OSWorld-Verified 벤치마크(`osworld-verified`)의 기관(organization) 정보가 프론트매터에 비어 있으며, 연관 기관 정보(`src/content/organizations/`)가 없습니다.
+
+## 시도한 것
+OSWorld 공식 페이지와 논문을 바탕으로 벤치마크 데이터를 수집했으나, 어떤 단일 기관(또는 주요 기관 ID)으로 지정해야 할지 명확하지 않아 `organization` 필드를 생략했습니다. 논문 저자는 홍콩대(HKU), Carnegie Mellon University, Salesforce Research, University of Waterloo 등으로 다양합니다.
+
+## 요청
+해당 벤치마크를 대표할 기관(예: `hku-nlp`, `os-world-team` 등)을 확정하고, `src/content/organizations/` 에 기관 스텁(stub) 또는 상세 정보를 작성해주시기 바랍니다. 그 후 벤치마크 파일의 `organization` 필드 업데이트도 필요합니다.

--- a/src/data/journal/2026-05-15-profile-benchmark.md
+++ b/src/data/journal/2026-05-15-profile-benchmark.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-15
+agent: profile-benchmark
+status: completed
+summary: "OSWorld-Verified와 Toolathlon 벤치마크 상세 페이지 및 기관 정보를 작성했습니다."
+---
+
+## Todo
+- [x] OSWorld-Verified 벤치마크 상세 페이지 작성
+- [x] OSWorld-Verified 기관 조사 이슈 티켓 생성
+- [x] Toolathlon 벤치마크 상세 페이지 작성
+- [x] Toolathlon 관련 기관(hkust-nlp) 스텁 및 이슈 티켓 생성
+
+## 조사 내역
+- 02:30 OSWorld-Verified 개요 조사 ← https://os-world.github.io/ , https://arxiv.org/abs/2404.07972
+- 02:40 Toolathlon 개요 조사 ← https://github.com/hkust-nlp/Toolathlon , https://arxiv.org/abs/2510.25726
+
+## 수행한 작업
+- [x] `osworld-verified` 벤치마크 페이지(`src/content/benchmarks/osworld-verified.md`) 작성 ← https://arxiv.org/abs/2404.07972
+- [x] `osworld-verified` 기관 미상 이슈(`src/data/issues/2026-05-16-profile-benchmark-osworld-verified-org.md`) 생성
+- [x] `toolathlon` 벤치마크 페이지(`src/content/benchmarks/toolathlon.md`) 작성 ← https://arxiv.org/abs/2510.25726
+- [x] `hkust-nlp` 기관 스텁(`src/content/organizations/hkust-nlp.md`) 작성 ← https://github.com/hkust-nlp
+- [x] `hkust-nlp` 기관 상세 조사 이슈(`src/data/issues/2026-05-16-profile-benchmark-hkust-nlp.md`) 생성
+
+## 판단 / 고민
+- OSWorld-Verified의 경우 논문 저자가 여러 기관(HKU, Carnegie Mellon 등)에 소속되어 있어 벤치마크를 대표할 단일 `organization`을 식별하기 어려웠습니다. 이에 따라 프론트매터에서 `organization`을 생략하고 기관 확정을 위한 이슈 티켓을 생성했습니다.
+
+## 이슈 제기
+- issues/2026-05-16-profile-benchmark-osworld-verified-org.md
+- issues/2026-05-16-profile-benchmark-hkust-nlp.md


### PR DESCRIPTION
Automated daily cycle execution of the `profile-benchmark` task. 

**Changes Include:**
- Drafted benchmark pages for **OSWorld-Verified** and **Toolathlon** based on paper and official repository sources.
- Generated an organization stub and tracking issue for **HKUST NLP**.
- Created an issue ticket for the missing organization context for **OSWorld-Verified**.
- Executed validation using `bun run build` successfully.
- Maintained the daily journal capturing tasks performed.

---
*PR created automatically by Jules for task [99804740519983574](https://jules.google.com/task/99804740519983574) started by @GGJJack*