### PR TITLE
docs(journal): generate daily report and update journal entry for 2026-05-15

### DIFF
--- a/src/data/journal/2026-05-16-journal.md
+++ b/src/data/journal/2026-05-16-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-16
+agent: journal
+status: completed
+summary: "전일(2026-05-15) 에이전트 수행 로그 취합 및 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- [x] 2026-05-15 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark 저널 파싱 및 취합
+- [x] `src/data/updates/2026-05-15-daily.md` 데일리 리포트 발행

--- a/src/data/updates/2026-05-15-daily.md
+++ b/src/data/updates/2026-05-15-daily.md
@@ -1,0 +1,41 @@
+---
+date: 2026-05-15
+type: note
+title: "데일리 리포트 · 2026-05-15"
+summary: "Cohere, Moonshot 등 신규 모델 등록 및 보강과 OSWorld-Verified, Toolathlon 벤치마크 프로파일 작성이 완료되었습니다."
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: eeve-korean-10.8b (https://huggingface.co/yanolja/EEVE-Korean-10.8B-v1.0)
+- 신규: kimi-k2.6 (https://www.moonshot.cn/)
+- 신규: command-a-reasoning-08-2025 (https://docs.cohere.com/docs/models)
+- 신규: command-a-translate-08-2025 (https://docs.cohere.com/docs/models)
+- 신규: command-a-vision-07-2025 (https://docs.cohere.com/docs/models)
+- 보강: command-a-03-2025 · 가격 정보
+- 보강: mistral-medium-3-5 · 가격 정보
+- 보강: exaone-3.0, exaone-4-5-33b, llama-4 family · 가격 정보 null 초기화
+
+### 벤치마크 (collect-benchmark)
+- 신규: (없음)
+- 특이사항: Kimi K2.5, Qwen3-30B-A3B, Gemma 3, NVIDIA Nemotron 3 Nano 점수 업데이트는 출처 불분명 정책에 따라 생략
+
+## 상세 페이지 작성 (profile)
+
+### 모델 프로파일 (profile-model)
+- models/llama-4-scout-17b · status=draft
+- models/eeve-korean-10.8b · status=draft
+
+### 벤치마크 프로파일 (profile-benchmark)
+- benchmarks/osworld-verified · status=draft (https://arxiv.org/abs/2404.07972)
+- benchmarks/toolathlon · status=draft (https://arxiv.org/abs/2510.25726)
+- organizations/hkust-nlp · 스텁 작성 (https://github.com/hkust-nlp)
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 0건 (수행 내역 없음)
+
+## 미해결 이슈
+- issues/2026-05-15-collect-benchmark-unverified.md — 신규 추가된 모델들의 벤치마크 점수 출처 확인 실패
+- issues/2026-05-16-profile-benchmark-osworld-verified-org.md — osworld-verified 기관 미상
+- issues/2026-05-16-profile-benchmark-hkust-nlp.md — hkust-nlp 기관 상세 조사 필요


### PR DESCRIPTION
Generated the daily report for `2026-05-15` by parsing and aggregating data from yesterday's agent execution journals (`collect-llm`, `collect-benchmark`, `profile-model`, `profile-benchmark`). Created the agent's own journal log for `2026-05-16` as requested by the trigger logic, setting the status to complete. Tested frontmatter schema via `bun install && bun run build`.

---
*PR created automatically by Jules for task [13840324964959249294](https://jules.google.com/task/13840324964959249294) started by @GGJJack*