### PR TITLE
feat(benchmark): add kimi-k2.6 scores and log unverified models

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -901,6 +901,44 @@
         "source": "official",
         "sourceUrl": "https://www.deeplearning.ai/the-batch/google-releases-gemma-3-vision-language-models-with-open-weights"
       }
+    },
+    "kimi-k2.6": {
+      "gpqa": {
+        "value": 90.5,
+        "date": "2026-05-16",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/moonshotai/Kimi-K2.6"
+      },
+      "swe-bench-pro": {
+        "value": 58.6,
+        "date": "2026-05-16",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/moonshotai/Kimi-K2.6"
+      },
+      "swe-bench-verified": {
+        "value": 80.2,
+        "date": "2026-05-16",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/moonshotai/Kimi-K2.6"
+      },
+      "terminal-bench-2-0": {
+        "value": 66.7,
+        "date": "2026-05-16",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/moonshotai/Kimi-K2.6"
+      },
+      "osworld-verified": {
+        "value": 73.1,
+        "date": "2026-05-16",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/moonshotai/Kimi-K2.6"
+      },
+      "toolathlon": {
+        "value": 50,
+        "date": "2026-05-16",
+        "source": "official",
+        "sourceUrl": "https://huggingface.co/moonshotai/Kimi-K2.6"
+      }
     }
   }
 }

--- a/src/data/issues/2026-05-17-collect-benchmark-unverified-command-a.md
+++ b/src/data/issues/2026-05-17-collect-benchmark-unverified-command-a.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-17
+agent: collect-benchmark
+severity: minor
+target: llm/command-a
+---
+
+## 상황
+`command-a-reasoning-08-2025`, `command-a-translate-08-2025`, `command-a-vision-07-2025` 의 벤치마크 점수 출처를 찾을 수 없음.
+
+## 시도한 것
+공식 웹사이트 및 검색을 시도했으나, 프로젝트에서 추적하는 벤치마크 점수를 명확히 찾지 못함.
+
+## 요청
+Cohere Command A 패밀리 신규 모델들의 공신력 있는 벤치마크 지표 확보 및 점수 추가.

--- a/src/data/issues/2026-05-17-collect-benchmark-unverified-eeve-korean-10.8b.md
+++ b/src/data/issues/2026-05-17-collect-benchmark-unverified-eeve-korean-10.8b.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-17
+agent: collect-benchmark
+severity: minor
+target: llm/eeve-korean-10.8b
+---
+
+## 상황
+`eeve-korean-10.8b` 의 벤치마크 점수 출처를 찾을 수 없음.
+
+## 시도한 것
+공식 HuggingFace 저장소를 확인했으나 추적 중인 벤치마크 지표를 명확히 확인할 수 없었음.
+
+## 요청
+`eeve-korean-10.8b` 의 공신력 있는 벤치마크 지표 확보 및 점수 추가.

--- a/src/data/journal/2026-05-16-collect-benchmark.md
+++ b/src/data/journal/2026-05-16-collect-benchmark.md
@@ -1,0 +1,23 @@
+---
+date: 2026-05-16
+agent: collect-benchmark
+status: completed
+summary: "kimi-k2.6 점수 추가 및 그 외 모델 점수 미확인 이슈 티켓 발행"
+---
+
+## Todo
+- [x] 신규 추가된 LLM 모델(kimi-k2.6, eeve-korean-10.8b, command-a 패밀리)의 점수 매칭
+
+## 조사 내역
+- 01:40 kimi-k2.6 공식 벤치마크 확인 ← https://huggingface.co/moonshotai/Kimi-K2.6
+- 01:45 eeve-korean-10.8b, command-a-reasoning-08-2025, command-a-translate-08-2025, command-a-vision-07-2025 벤치마크 점수 검색 시도 (명확한 수치/출처 확인 실패)
+
+## 수행한 작업
+- [x] kimi-k2.6 의 gpqa, swe-bench-pro, swe-bench-verified, terminal-bench-2-0, osworld-verified 점수 추가 ← https://huggingface.co/moonshotai/Kimi-K2.6
+
+## 판단 / 고민
+- eeve-korean-10.8b 와 command-a 패밀리 모델들의 벤치마크 점수는 출처를 확보하지 못해 업데이트 생략 및 이슈 티켓 생성.
+
+## 이슈 제기
+- issues/2026-05-17-collect-benchmark-unverified-eeve-korean-10.8b.md
+- issues/2026-05-17-collect-benchmark-unverified-command-a.md


### PR DESCRIPTION
This PR addresses the `collect-benchmark` cycle for newly collected LLM models. 

1. **Benchmark score matching**: Successfully found and verified scores for the `kimi-k2.6` model on GPQA, SWE-Bench Pro, SWE-Bench Verified, Terminal-Bench 2.0, and OSWorld-Verified benchmarks using its official Hugging Face source. Used the `benchmark.ts` script to strictly manage and update `llm.json`.
2. **Missing data issues**: Created tracking tickets for models (`eeve-korean-10.8b` and the `command-a` family) that lacked explicit or verifiable benchmark scores aligning with our currently tracked lists, adhering to the project's strict "no unverified fields" policy.
3. **Journal updates**: Created the `2026-05-16-collect-benchmark.md` journal file documenting the actions, decisions, and outcomes from this cycle.

All JSON additions were done programmatically through the approved CLI, and no regressions were found during `bun run build` validation.

---
*PR created automatically by Jules for task [7890205342347725628](https://jules.google.com/task/7890205342347725628) started by @GGJJack*