### PR TITLE
Create daily report for 2026-05-16

### DIFF
--- a/src/data/journal/2026-05-17-journal.md
+++ b/src/data/journal/2026-05-17-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-17
+agent: journal
+status: completed
+summary: "전일(2026-05-16) 에이전트 수행 로그 취합 및 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- [x] 2026-05-16 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark, reinforce 저널 파싱 및 취합
+- [x] `src/data/updates/2026-05-16-daily.md` 데일리 리포트 발행

--- a/src/data/updates/2026-05-16-daily.md
+++ b/src/data/updates/2026-05-16-daily.md
@@ -1,0 +1,39 @@
+---
+date: 2026-05-16
+type: note
+title: "데일리 리포트 · 2026-05-16"
+summary: "Upstage Solar Mini, xAI Grok 4.3 등 신규 모델 등록, Kimi K2.6 벤치마크 점수 추가, 그리고 LLM 메타데이터(가격/라이선스) 및 상세 프로필(Grok 4.3, Kimi K2.5) 작성이 완료되었습니다."
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: solar-mini (https://www.upstage.ai/blog/en/introducing-solar-mini-compact-yet-powerful)
+- 신규: grok-4-3 (https://docs.x.ai/developers/models)
+- 보강: deepseek-v3.2 · 가격 정보
+- 보강: glm-5 · 가격 정보
+- 보강: gemma-3-4b/12b/27b · 가격 및 컨텍스트
+- 보강: ministral-3-3b/8b/14b · 가격 및 컨텍스트
+- 보강: devstral-2 · 가격 및 컨텍스트
+- 보강: grok-4.1-fast, grok-4.20-multi-agent, grok-4-20 · 상태(deprecated) 업데이트
+- 보강: hyperclova-x · 가격 정보
+
+### 벤치마크 (collect-benchmark)
+- 신규: kimi-k2.6 점수 추가 (gpqa, swe-bench-pro, swe-bench-verified, terminal-bench-2-0, osworld-verified) (https://huggingface.co/moonshotai/Kimi-K2.6)
+
+## 상세 페이지 작성 (profile)
+
+### 모델 프로파일 (profile-model)
+- models/grok-4-3 · status=published
+- models/kimi-k2.5 · status=draft
+
+### 벤치마크 프로파일 (profile-benchmark)
+- benchmarks/terminal-bench-2-0 · 페이지 작성 (https://www.tbench.ai/leaderboard/terminal-bench/2.0)
+
+## 이슈 처리 (reinforce)
+- 해결 1건 / 부분 2건 / 잔여 28건
+
+## 미해결 이슈
+- issues/2026-05-17-collect-benchmark-unverified-eeve-korean-10.8b.md — eeve-korean-10.8b 점수 출처 미상
+- issues/2026-05-17-collect-benchmark-unverified-command-a.md — command-a 패밀리 점수 출처 미상
+- issues/2026-05-17-profile-benchmark-terminal-bench-2-0-org.md — 기관 단일 매핑 모호


### PR DESCRIPTION
Generates the daily report (`src/data/updates/2026-05-16-daily.md`) using data aggregated from the agent logs on 2026-05-16. Creates the matching journal log for the journal agent marking it as completed.

---
*PR created automatically by Jules for task [4158406208107091771](https://jules.google.com/task/4158406208107091771) started by @GGJJack*