### PR TITLE
reinforce: Escalate Mistral benchmark issues to blocker

### DIFF
--- a/src/data/issues/2026-04-30-collect-benchmark-mistral-large-3.md
+++ b/src/data/issues/2026-04-30-collect-benchmark-mistral-large-3.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-30
 agent: collect-benchmark
-severity: minor
+severity: blocker
 target: llm/mistral-large-3
 ---
 
@@ -10,7 +10,7 @@ target: llm/mistral-large-3
 ## 시도한 것
 - 관련 뉴스 등 검색했으나 정확한 수치를 확인할 수 없었음. (이전 검색 결과의 신뢰성 문제로 데이터 삭제 처리함)
 ## 요청
-- Mistral Large 3 모델의 정확한 벤치마크 점수를 신뢰할 수 있는 출처를 통해 탐색하여 등록할 것.
+- Mistral Large 3 모델의 정확한 벤치마크 점수를 신뢰할 수 있는 출처를 통해 탐색하여 등록할 것. (사람 에스컬레이션 필요: 공식 텍스트 수치 확인 불가)
 ## 진행 내역
 - 2026-04-30 (reinforce): LMArena 리더보드에서 Chatbot Arena ELO 점수(1415) 확인. 공식 및 커뮤니티 출처(Artificial Analysis, Hugging Face 등)를 정밀 탐색했으나 MMLU, HumanEval, GSM8K의 구체적 수치는 여전히 미기재 상태로 확인됨.
 - 2026-05-01 (reinforce): 'Chatbot Arena ELO' 신규 벤치마크 정의를 추가하고 Mistral Large 3의 점수(1415, community)를 등록함. MMLU 등 아카데믹 점수는 여전히 공식 미기재 상태이므로 티켓을 유지함.
@@ -25,3 +25,4 @@ target: llm/mistral-large-3
 - 2026-05-15 (reinforce): 공식 블로그 및 Hugging Face 모델 카드(Mistral-Large-3-675B-Instruct-2512)를 재검토하였으나, HumanEval 및 GSM8K 점수는 여전히 이미지로만 제공되며 텍스트 기반 공식 수치는 확인되지 않음. Mistral Large v2(2407)와의 혼동을 방지하기 위해 추가 데이터 등록 없이 티켓을 유지함.
 
 - 2026-05-16 (reinforce): 공식 블로그 및 관련 기술 문서를 정밀 재탐색하였으나 Mistral Large 3의 HumanEval 및 GSM8K 공식 텍스트 점수는 여전히 확인되지 않음. 기존에 잘못된 출처 URL로 등록되어 있던 MMLU 및 GPQA 점수의 URL을 공식 Hugging Face 경로로 수정함.
+- 2026-05-17 (reinforce): 공식 블로그(mistral.ai/news/mistral-3/) 및 기술 리포트(arXiv:2601.08584)를 재조사함. HumanEval 및 GSM8K 점수는 여전히 텍스트로 명시되지 않고 타 모델과의 비교 차트로만 존재함. 다수의 reinforce 세션에서 해결되지 않아 severity를 blocker로 격상하고 사람 에스컬레이션을 요청함.

--- a/src/data/issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md
+++ b/src/data/issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-30
 agent: collect-benchmark
-severity: minor
+severity: blocker
 target: llm/mistral-medium-3-5
 ---
 
@@ -10,7 +10,7 @@ target: llm/mistral-medium-3-5
 ## 시도한 것
 - 관련 뉴스, Hugging Face 모델 카드, Ollama 등을 검색했으나 명확한 HumanEval 점수를 찾을 수 없었음.
 ## 요청
-- Mistral Medium 3.5 모델의 HumanEval 점수를 다른 신뢰할 수 있는 출처나 커뮤니티 리더보드에서 탐색하여 등록할 것.
+- Mistral Medium 3.5 모델의 HumanEval 점수를 다른 신뢰할 수 있는 출처나 커뮤니티 리더보드에서 탐색하여 등록할 것. (사람 에스컬레이션 필요: 공식 수치 미공개)
 ## 진행 내역
 - 2026-04-30 (reinforce): 공식 블로그, Hugging Face 모델 카드, 주요 리더보드를 탐색했으나 SWE-bench Verified 외의 HumanEval 점수는 여전히 확인되지 않음.
 - 2026-05-01 (reinforce): 추가 탐색 결과 Mistral Medium 3.5의 공식 HumanEval 점수는 여전히 미공개 상태임.
@@ -25,3 +25,4 @@ target: llm/mistral-medium-3-5
 - 2026-05-15 (reinforce): 공식 블로그 및 Hugging Face 모델 카드(Mistral-Medium-3.5-128B)를 재탐색하였으나 HumanEval 공식 점수는 여전히 미기재 상태임. 타 모델(v2)의 점수와 혼동될 수 있는 데이터는 배제하였으며, 추가 공식 발표가 있을 때까지 티켓을 유지함.
 
 - 2026-05-16 (reinforce): 공식 블로그 및 Artificial Analysis 등 주요 출처를 재탐색하였으나 HumanEval 공식 점수는 여전히 미공개 상태임. 추가 데이터 확인 시까지 티켓 유지함.
+- 2026-05-17 (reinforce): 공식 블로그(mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/)를 재확인함. SWE-bench Verified(77.6%)와 Tau-bench(91.4) 점수만 명시되어 있으며 HumanEval은 여전히 확인되지 않음. 반복된 시도에도 정보를 얻지 못해 severity를 blocker로 격상하고 사람 에스컬레이션을 요청함.

--- a/src/data/journal/2026-05-17-reinforce.md
+++ b/src/data/journal/2026-05-17-reinforce.md
@@ -1,0 +1,25 @@
+---
+date: 2026-05-17
+agent: reinforce
+status: completed
+summary: "Mistral Large 3 및 Medium 3.5 벤치마크 누락 이슈 조사 및 에스컬레이션"
+---
+
+## Todo
+- [x] Process 2026-04-30-collect-benchmark-mistral-large-3.md
+- [x] Process 2026-04-30-collect-benchmark-mistral-medium-3-5.md
+
+## 조사 내역
+- 10:00 작업 시작
+- 10:15 Mistral Large 3 (mistral.ai/news/mistral-3/) 조사: MMLU(85.5%), GPQA(43.9%)는 확인되나 HumanEval, GSM8K는 텍스트 수치 미공개.
+- 10:30 Mistral Medium 3.5 (mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/) 조사: SWE-bench Verified(77.6%), Tau-bench(91.4) 외 HumanEval 미공개.
+
+## 수행한 작업
+- [x] `src/data/issues/2026-04-30-collect-benchmark-mistral-large-3.md`: severity blocker 격상 및 사람 에스컬레이션 요청 추가.
+- [x] `src/data/issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md`: severity blocker 격상 및 사람 에스컬레이션 요청 추가.
+
+## 판단 / 고민
+- 공식 블로그와 기술 리포트에서 여러 차례 조사했으나 특정 지표(HumanEval, GSM8K)를 의도적으로 텍스트 수치 대신 차트로만 제공하는 것으로 보임. 에이전트 수준에서 더 이상의 추정이 불가하므로 사람의 확인이 필요한 단계로 판단함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This PR addresses pending benchmark collection issues for Mistral Large 3 and Mistral Medium 3.5. After extensive searching across official Mistral AI blogs, technical reports (arXiv:2601.08584), and community leaderboards (Artificial Analysis, Hugging Face), it was determined that text-based scores for HumanEval and GSM8K are currently not publicly available for these specific model versions (only provided as comparison charts).

Following the 'reinforce' skill guidelines, these issues have been escalated:
1. Increased severity to 'blocker'.
2. Added '사람 에스컬레이션 필요' (Human escalation required) to the requests.
3. Appended detailed logs of the investigation to the issue tickets.
4. Created and finalized the daily journal for 2026-05-17.

Build integrity was verified with `bun run build`.

Fixes #222

---
*PR created automatically by Jules for task [2193950384741478806](https://jules.google.com/task/2193950384741478806) started by @GGJJack*