### PR TITLE
feat(journal): generate daily report for 2026-05-17

### DIFF
--- a/src/data/journal/2026-05-18-journal.md
+++ b/src/data/journal/2026-05-18-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-18
+agent: journal
+status: completed
+summary: "전일(2026-05-17) 에이전트 수행 로그 취합 및 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- [x] 2026-05-17 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark, reinforce 저널 파싱 및 취합
+- [x] `src/data/updates/2026-05-17-daily.md` 데일리 리포트 발행

--- a/src/data/updates/2026-05-17-daily.md
+++ b/src/data/updates/2026-05-17-daily.md
@@ -1,0 +1,50 @@
+---
+date: 2026-05-17
+type: note
+title: 데일리 리포트 · 2026-05-17
+summary: "신규 모델 및 벤치마크 점수 등록, 프로필 작성 완료 및 누락 데이터 이슈 발견"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- Upstage Syn Pro 등록  ← https://www.upstage.ai/blog/ja/upstage-ai-jp-syn-pro
+- Qwen-MT 등록  ← https://qwenlm.github.io/blog/qwen-mt/
+- Qwen3Guard 등록  ← https://qwenlm.github.io/blog/qwen3guard/
+- DeepSeek-V4 Preview 등록  ← https://www.deepseek.com
+- Claude Design 등록  ← https://www.anthropic.com/news/claude-design-anthropic-labs
+- Kimi K2.6 보강 (contextWindow)  ← https://www.moonshot.cn/
+- Sakana AI KAME 교차 발견 등록 (stt, realtime=true)  ← https://sakana.ai/kame-icassp-2026/
+- 빌드 및 검증
+- `llm.json` 에 Syn Pro, Qwen-MT, Qwen3Guard, DeepSeek-V4 Preview, Claude Design 추가
+- `llm.json` 의 Kimi K2.6 메타데이터 보강
+- `stt.json` 에 KAME 추가 (realtime=true)
+
+### 벤치마크 (collect-benchmark)
+- 신규 LLM 모델(solar-mini, grok-4-3) 벤치마크 점수 등록 (collect-llm 후속)
+- grok-4-3 점수 매칭 (GPQA, Chatbot Arena ELO)
+- `grok-4-3` 모델의 GPQA 점수 등록 (84.6%) ← https://x.ai/blog/grok-3
+- `grok-4-3` 모델의 Chatbot Arena ELO 점수 등록 (1402) ← https://x.ai/blog/grok-3
+- `solar-mini` 의 출처 검증 이슈 티켓 생성 완료
+- `grok-4-3` 의 누락 벤치마크 데이터에 대한 이슈 티켓 생성 완료
+
+## 상세 페이지 작성 (profile)
+- Kimi K2.6 상세 페이지 작성 (`src/content/models/kimi-k2.6.md`)  ← https://www.kimi.com/blog/kimi-k2-6
+- Syn Pro 상세 페이지 작성 (`src/content/models/syn-pro.md`)  ← https://www.upstage.ai/blog/ja/upstage-ai-jp-syn-pro
+- `bun run build` 로 검증
+- `src/content/models/kimi-k2.6.md` 신규 생성 및 내용 작성 (status: published)
+- `src/content/models/syn-pro.md` 신규 생성 및 내용 작성 (status: published)
+- arena-hard-v2 프로필 보완 및 published 전환
+- google-research 기관 스텁 내용 채우기 및 published 전환
+- `arena-hard-v2 벤치마크 상세 정보 보완 및 published 전환` ← https://lmsys.org/blog/2024-04-19-arena-hard/
+- `google-research 기관 프로필 보완 및 published 전환` ← https://research.google/
+
+## 이슈 처리 (reinforce)
+- Process 2026-04-30-collect-benchmark-mistral-large-3.md
+- Process 2026-04-30-collect-benchmark-mistral-medium-3-5.md
+- `src/data/issues/2026-04-30-collect-benchmark-mistral-large-3.md`: severity blocker 격상 및 사람 에스컬레이션 요청 추가.
+- `src/data/issues/2026-04-30-collect-benchmark-mistral-medium-3-5.md`: severity blocker 격상 및 사람 에스컬레이션 요청 추가.
+
+## 미해결 이슈
+- issues/2026-05-18-collect-benchmark-solar-mini.md — 신규 벤치마크 데이터 수집 중 발생한 이슈
+- issues/2026-05-18-collect-benchmark-grok-4-3.md — 신규 벤치마크 데이터 수집 중 발생한 이슈


### PR DESCRIPTION
Generated the `src/data/updates/2026-05-17-daily.md` daily report programmatically by parsing yesterday's `collect-*`, `profile-*`, and `reinforce` journals. Also created the `src/data/journal/2026-05-18-journal.md` execution log with `status: completed` and verified build schemas.

---
*PR created automatically by Jules for task [17334513023120053954](https://jules.google.com/task/17334513023120053954) started by @GGJJack*