### PR TITLE
chore(collect-benchmark): Update Grok 4.3 ticket and create daily journal

### DIFF
--- a/src/data/issues/2026-05-18-collect-benchmark-grok-4-3.md
+++ b/src/data/issues/2026-05-18-collect-benchmark-grok-4-3.md
@@ -14,3 +14,4 @@ x.ai/blog/grok-3 에서 GPQA 84.6%, Chatbot Arena 1402점은 확인하여 입력
 
 ## 요청
 해당 모델에 대한 추가적인 벤치마크(MMLU-Pro 등) 점수가 공개되었는지 확인하고 수집 및 점수 등록 요청.
+- 2026-05-18 (collect-benchmark): Google 검색 및 Artificial Analysis, OpenRouter, Vals AI, MindStudio 등 신뢰할 수 있는 커뮤니티를 탐색했으나 Grok 4.3 모델의 MMLU-Pro 등 추가 벤치마크의 공식적인 단일 수치(텍스트)를 확인할 수 없었습니다. 추가 공개 시까지 티켓을 유지합니다.

--- a/src/data/journal/2026-05-18-collect-benchmark.md
+++ b/src/data/journal/2026-05-18-collect-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-05-18
+agent: collect-benchmark
+status: completed
+summary: "신규 모델 벤치마크 점수 조사 (Grok 4.3 등) 및 이슈 티켓 업데이트"
+---
+
+## Todo
+- 신규 등록 모델의 벤치마크 점수 매칭
+
+## 조사 내역
+- 01:30  Grok 4.3 벤치마크 점수 탐색 (MMLU-Pro 등) 결과, 공식 텍스트 기반 수치 미발견. 기존 티켓 유지 결정. ← https://artificialanalysis.ai/models/grok-4-3
+
+## 수행한 작업
+- [x] `src/data/issues/2026-05-18-collect-benchmark-grok-4-3.md` 티켓에 진행 내역 추가 (공식 점수 미발견) ← https://artificialanalysis.ai/models/grok-4-3
+
+## 판단 / 고민
+- 신규 모델들의 세부 벤치마크(MMLU-Pro 등)가 공식 블로그에 텍스트 형태로 명시되지 않아, 추후 리더보드 등재나 공식 발표를 기다려야 할 것으로 판단됨.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This PR logs the daily `collect-benchmark` run for 2026-05-18. It investigates Grok 4.3's missing benchmark scores, confirms that reliable textual scores for MMLU-Pro are not yet officially available, updates the corresponding issue ticket to keep it open, and creates the daily journal.

---
*PR created automatically by Jules for task [15853144087492189369](https://jules.google.com/task/15853144087492189369) started by @GGJJack*