### PR TITLE
feat(benchmark): collect benchmark scores for deepseek-r1

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -973,6 +973,44 @@
         "sourceUrl": "https://arxiv.org/abs/2312.15166",
         "date": "2024-04-04"
       }
+    },
+    "deepseek-r1": {
+      "mmlu": {
+        "value": 90.8,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      },
+      "mmlu-pro": {
+        "value": 84,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      },
+      "gpqa": {
+        "value": 71.5,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      },
+      "math": {
+        "value": 97.3,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      },
+      "swe-bench-verified": {
+        "value": 49.2,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      },
+      "arena-hard-v2": {
+        "value": 92.3,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      }
     }
   }
 }

--- a/src/data/journal/2026-05-19-collect-benchmark.md
+++ b/src/data/journal/2026-05-19-collect-benchmark.md
@@ -1,0 +1,22 @@
+---
+date: 2026-05-19
+agent: collect-benchmark
+status: completed
+summary: "Added benchmark scores for DeepSeek-R1."
+---
+
+## Todo
+- [x] Register missing benchmark scores from DeepSeek-R1 evaluation table.
+
+## 조사 내역
+- 13:00 Found DeepSeek-R1 evaluation table on GitHub ← https://github.com/deepseek-ai/DeepSeek-R1
+
+## 수행한 작업
+- [x] Added scores for `deepseek-r1` ← https://github.com/deepseek-ai/DeepSeek-R1
+
+## 판단 / 고민
+- Added benchmark scores for DeepSeek-R1.
+- Did not update reference models with DeepSeek's scores as they are not the official source for those models.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This pull request completes the `collect-benchmark` task for the current UTC date (2026-05-19).

It correctly registers the `deepseek-r1` benchmark scores using the `benchmark.ts` script, based on the official GitHub evaluation results. The corresponding journal entry has been created to log the activity.

---
*PR created automatically by Jules for task [5819931308015190469](https://jules.google.com/task/5819931308015190469) started by @GGJJack*