### PR TITLE
Update benchmarks and profile-benchmark daily journal

### DIFF
--- a/src/content/benchmarks/osworld-verified.md
+++ b/src/content/benchmarks/osworld-verified.md
@@ -1,11 +1,13 @@
 ---
 benchmarkId: osworld-verified
 domain: llm
-status: draft
+status: published
 updated: 2026-05-15
 sources:
+  - "https://huggingface.co/spaces/xlang-ai/OSWorld-Leaderboard"
   - "https://os-world.github.io/"
   - "https://arxiv.org/abs/2404.07972"
+organization: xlang-ai
 paperUrl: "https://arxiv.org/abs/2404.07972"
 highlights:
   - "Ubuntu, Windows, macOS 등 실제 컴퓨터 환경에서 멀티모달 에이전트의 워크플로우를 테스트"

--- a/src/content/benchmarks/swe-bench-pro.md
+++ b/src/content/benchmarks/swe-bench-pro.md
@@ -1,9 +1,10 @@
 ---
 benchmarkId: swe-bench-pro
 domain: llm
-status: draft
+status: published
 updated: 2026-05-14
 sources:
+  - "https://github.com/scaleapi/swe-bench-pro"
   - https://labs.scale.com/leaderboard/swe_bench_pro_public
   - https://labs.scale.com/papers/swe_bench_pro
 organization: scale-ai

--- a/src/content/benchmarks/toolathlon.md
+++ b/src/content/benchmarks/toolathlon.md
@@ -1,9 +1,10 @@
 ---
 benchmarkId: toolathlon
 domain: llm
-status: draft
+status: published
 updated: 2026-05-15
 sources:
+  - "https://huggingface.co/datasets/hkust-nlp/Toolathlon"
   - "https://github.com/hkust-nlp/Toolathlon"
   - "https://arxiv.org/abs/2510.25726"
 organization: hkust-nlp

--- a/src/content/organizations/xlang-ai.md
+++ b/src/content/organizations/xlang-ai.md
@@ -1,0 +1,12 @@
+---
+orgId: xlang-ai
+name: XLang Lab
+type: academic
+status: draft
+updated: 2026-05-20
+sources:
+  - https://github.com/xlang-ai
+---
+
+# XLang Lab
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-05-20-profile-benchmark-xlang-ai-org.md
+++ b/src/data/issues/2026-05-20-profile-benchmark-xlang-ai-org.md
@@ -1,0 +1,12 @@
+---
+created: 2026-05-20
+agent: profile-benchmark
+severity: minor
+target: organization/xlang-ai
+---
+
+## 상황
+- OSWorld 벤치마크 제작 기관인 XLang Lab(`xlang-ai`)에 대한 기관 상세 정보가 부족하여 스텁만 생성됨.
+
+## 요청
+- `reinforce` 스킬을 통해 해당 기관의 개요 및 추가 정보 보강 필요.

--- a/src/data/journal/2026-05-19-profile-benchmark.md
+++ b/src/data/journal/2026-05-19-profile-benchmark.md
@@ -1,0 +1,14 @@
+---
+date: 2026-05-19
+agent: profile-benchmark
+status: completed
+summary: "OSWorld-Verified, Toolathlon, SWE-bench Pro 등 3개 벤치마크 published 승격 및 xlang-ai 기관 스텁 생성"
+---
+
+## 수행한 작업
+- [x] `osworld-verified` 벤치마크 상세 정보 및 기관(`xlang-ai`) 추가, published 로 승격.  ← https://huggingface.co/spaces/xlang-ai/OSWorld-Leaderboard
+- [x] `toolathlon` 벤치마크 추가 출처 등록 후 published 승격.  ← https://huggingface.co/datasets/hkust-nlp/Toolathlon
+- [x] `swe-bench-pro` 벤치마크 추가 출처 등록 후 published 승격.  ← https://github.com/scaleapi/swe-bench-pro
+
+## 이슈 제기
+- issues/2026-05-20-profile-benchmark-xlang-ai-org.md


### PR DESCRIPTION
This PR addresses the daily automated run for `profile-benchmark`. It identifies three recent benchmarks with `status: draft` (`osworld-verified`, `toolathlon`, and `swe-bench-pro`), researches and adds additional authoritative sources for them, and elevates them to `published` status. In addition, it establishes a stub entry for `xlang-ai` (the organization behind OSWorld) and creates an issue ticket for it to be processed by `reinforce`. Finally, it leaves a daily journal trail of the steps executed on 2026-05-19 UTC.

---
*PR created automatically by Jules for task [9533087400852783266](https://jules.google.com/task/9533087400852783266) started by @GGJJack*