### PR TITLE
Add Gemini 3.5 Flash and Gemini Omni Flash profiles

### DIFF
--- a/src/content/models/gemini-3.5-flash.md
+++ b/src/content/models/gemini-3.5-flash.md
@@ -1,0 +1,35 @@
+---
+modelId: gemini-3.5-flash
+domain: llm
+status: published
+updated: 2026-05-19
+sources:
+  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+  - https://ai.google.dev/pricing
+  - https://blog.google/innovation-and-ai/sundar-pichai-io-2026/
+features:
+  toolUse: true
+  vision: true
+  audioInput: true
+  audioOutput: true
+  extendedThinking: true
+highlights:
+  - "에이전트 워크플로우 및 코딩 작업에 최적화된 최첨단 성능"
+  - "Gemini 3.1 Pro를 능가하는 추론 속도 및 에이전틱 벤치마크 점수"
+  - "100만 토큰의 컨텍스트 윈도우와 경쟁사 대비 압도적인 출력 속도"
+relatedOrganization: google
+---
+
+# Gemini 3.5 Flash 소개
+
+## 개요
+Gemini 3.5 Flash는 2026년 5월 Google I/O에서 발표된 Gemini 3.5 시리즈의 첫 번째 모델입니다. "Frontier intelligence with action"이라는 모토 아래 개발된 이 모델은 고도의 지능과 압도적인 속도를 결합하여 복잡한 에이전트 워크플로우를 처리하는 데 특화되어 있습니다. 기존 Flash 시리즈의 강점인 저지연성을 유지하면서도, 코딩과 에이전트 작업에서는 상위급 모델인 Gemini 3.1 Pro를 능가하는 성능을 보여줍니다. 현재 Gemini 앱과 Google 검색의 AI 모드 기본 모델로 적용되어 전 세계 수십억 명의 사용자에게 제공되고 있습니다.
+
+## 기술 특징
+Gemini 3.5 Flash는 '에이전트 중심' 아키텍처를 채택하여 장기적인 계획(long-horizon planning)과 도구 활용 능력이 대폭 강화되었습니다. Terminal-Bench 2.1(76.2%) 및 MCP Atlas(83.6%) 등 주요 에이전틱 벤치마크에서 선두를 차지하며 실질적인 문제 해결 능력을 입증했습니다. 특히 출력 속도(Tokens per second) 면에서 다른 프론티어 모델들보다 최대 4배 빠르며, Artificial Analysis의 지능 지수와 속도 비교에서 우상단(고성능-고속) 영역을 점유하고 있습니다. 104만(1M) 토큰의 컨텍스트 윈도우를 지원하여 방대한 코드베이스나 복잡한 금융 문서를 한 번에 처리할 수 있는 효율성을 제공합니다.
+
+## 사용 사례
+이 모델은 자동화된 코드베이스 마이그레이션(예: Next.js 전환), 대규모 데이터 분석, 그리고 24시간 중단 없는 정보 에이전트 구축에 최적입니다. Google의 'Antigravity' 플랫폼과 결합하여 여러 개의 협업 서브에이전트를 구동함으로써 복잡한 비즈니스 프로세스를 자동화할 수 있습니다. 예를 들어, Macquarie Bank는 100페이지가 넘는 복잡한 고객 온보딩 문서를 분석하는 데 활용하고 있으며, Shopify는 전 세계 가맹점의 성장을 예측하기 위한 데이터 분석 에이전트로 이 모델을 사용하고 있습니다. 또한 개인용 AI 에이전트인 'Gemini Spark'의 기반 모델로서 사용자의 일상 업무를 돕는 역할을 수행합니다.
+
+## 한계
+Gemini 3.5 Flash는 속도와 에이전트 성능에 최적화되어 있으나, 극도로 정교한 창의적 글쓰기나 매우 깊은 수준의 인문학적 추론에서는 향후 출시될 'Gemini 3.5 Pro'에 비해 상대적으로 밀릴 수 있습니다. 또한 에이전트 기반의 자율적인 도구 사용이 활발해짐에 따라, 잘못된 계획 수립으로 인한 연쇄적인 오류가 발생할 위험이 있으므로 Antigravity와 같은 개발 플랫폼 내에서의 인간 감독(Human-in-the-loop)이 권장됩니다. Frontier Safety Framework에 따라 강화된 사이버 및 CBRN 안전 가드레일이 적용되어 있으나, 복잡한 외부 도구와 상호작용하는 에이전틱 작업 환경에서는 여전히 신중한 모니터링이 필요합니다.

--- a/src/content/models/gemini-omni-flash.md
+++ b/src/content/models/gemini-omni-flash.md
@@ -1,0 +1,36 @@
+---
+modelId: gemini-omni-flash
+domain: llm
+status: published
+updated: 2026-05-19
+sources:
+  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni/
+  - https://blog.google/innovation-and-ai/sundar-pichai-io-2026/
+  - https://deepmind.google/models/gemini-omni
+features:
+  toolUse: true
+  vision: true
+  audioInput: true
+  audioOutput: true
+  videoInput: true
+  videoOutput: true
+highlights:
+  - "비디오, 오디오, 텍스트 등 모든 입력을 자유자재로 조합하여 고품질 비디오를 생성"
+  - "대화형 자연어를 통한 비실시간/실시간 비디오 편집 및 스타일 변환 능력"
+  - "Gemini의 실세계 지식과 물리 법칙 이해를 결합한 사실적인 시각적 서사 구축"
+relatedOrganization: google
+---
+
+# Gemini Omni Flash 소개
+
+## 개요
+Gemini Omni Flash는 2026년 5월 Google I/O에서 공개된 차세대 생성형 멀티모달 모델 제품군인 'Gemini Omni'의 첫 번째 상용 모델입니다. 기존의 이미지 생성을 넘어 비디오 영역에서 "어떤 입력으로든 무엇이든 생성할 수 있는(Create anything from any input)" 능력을 갖추고 있습니다. Omni Flash는 단순한 패턴 매칭을 넘어 Gemini의 추론 능력과 창의성을 결합하여, 사용자가 대화하듯 자연스럽게 비디오를 제작하고 수정할 수 있는 환경을 제공합니다. 현재 Gemini 앱, Google Flow, YouTube Shorts 등에 통합되어 전 세계 사용자들이 이용할 수 있습니다.
+
+## 기술 특징
+Gemini Omni Flash의 핵심 기술적 진보는 비디오 데이터에 대한 깊은 물리적 이해와 상황 인지 능력입니다. 중력, 운동 에너지, 유체 역학 등 물리 법칙에 대한 직관적인 이해도가 개선되어 더욱 사실적인 움직임을 구현하며, 이를 Gemini의 역사·과학·문화적 배경 지식과 결합하여 의미 있는 스토리텔링이 가능한 영상을 생성합니다. 특히 대화형 편집 기능을 통해 캐릭터의 일관성을 유지하면서 환경, 카메라 각도, 특정 객체 등을 여러 단계(multi-turn)에 걸쳐 정밀하게 수정할 수 있습니다. 생성된 모든 콘텐츠에는 식별 불가능한 디지털 워터마크인 SynthID가 포함되어 투명성을 보장합니다.
+
+## 사용 사례
+이 모델은 크리에이터와 마케터를 위한 강력한 영상 제작 도구로 활용됩니다. 예를 들어, 사용자가 직접 촬영한 영상에 "조각상을 거품으로 만들어줘"라고 요청하거나 특정 동작을 추가하는 등 창의적인 편집이 가능합니다. YouTube Shorts와 YouTube Create 앱에서는 일반 사용자들이 복잡한 편집 기술 없이도 고품질 영상을 제작할 수 있도록 지원합니다. 또한 교육적 목적의 클레이 애니메이션 설명 영상 제작, 텍스트 설명을 기반으로 한 인터랙티브 하드웨어 시각화, 기업 브랜딩 컨셉을 위한 병렬 시각화 등 비즈니스 및 연구 분야에서도 폭넓게 사용됩니다. 'Avatars' 기능을 통해 자신의 음성과 모습으로 디지털 버전을 생성하여 영상을 만드는 것도 가능합니다.
+
+## 한계
+Gemini Omni Flash는 비디오 생성에 특화되어 있으나, 현재 공식적으로 지원되는 오디오 입력은 음성(voice) 레퍼런스로 제한되어 있으며 다른 유형의 오디오 입력은 향후 업데이트될 예정입니다. 또한 비디오 내에서의 오디오 및 음성 편집 기능은 책임감 있는 AI 사용과 정책 준수를 위해 현재 엄격하게 관리 및 테스트 중에 있어 일반 사용자의 접근이 제한될 수 있습니다. 고도로 사실적인 영상을 생성할 수 있는 만큼 딥페이크나 오정보 생성의 위험이 상존하므로, Google의 책임 정책에 따른 가이드라인 준수가 필수적이며 콘텐츠 신뢰성 확인 도구를 통한 검증 절차를 거쳐야 합니다.

--- a/src/data/journal/2026-05-19-profile-model.md
+++ b/src/data/journal/2026-05-19-profile-model.md
@@ -1,0 +1,23 @@
+---
+date: 2026-05-19
+agent: profile-model
+status: completed
+summary: "Google I/O 2026 신규 발표 모델(Gemini 3.5 Flash, Gemini Omni Flash) 프로파일 작성 완료"
+---
+
+## Todo
+- [x] Gemini 3.5 Flash 프로파일 작성 (`src/content/models/gemini-3.5-flash.md`)
+- [x] Gemini Omni Flash 프로파일 작성 (`src/content/models/gemini-omni-flash.md`)
+
+## 작업 내역
+- 2026-05-19 19:00 작업 시작
+- 대상 선정: Google I/O 2026에서 발표된 Gemini 3.5 Flash 및 Gemini Omni Flash
+- 조사 내용:
+    - Gemini 3.5 Flash: 에이전트 및 코딩 최적화, 기존 3.1 Pro 대비 성능 향상, 1M 컨텍스트 지원.
+    - Gemini Omni Flash: 비디오 기반 멀티모달 생성/편집 모델, 물리 법칙 이해 및 상황 인지 능력 강조.
+- `src/content/models/gemini-3.5-flash.md` 작성 (status: published)
+- `src/content/models/gemini-omni-flash.md` 작성 (status: published)
+- `bun run build`를 통한 Zod 스키마 검증 완료.
+
+## 결과
+- 신규 프로파일 2종 생성 및 배포 준비 완료.


### PR DESCRIPTION
I have created detailed profile pages for the newly announced Gemini 3.5 Flash and Gemini Omni Flash models. These profiles are written in Korean and include information on their technical characteristics, use cases, and known limitations, all supported by official sources from Google I/O 2026. I have also updated the task journal and verified the changes through a successful build and visual inspection of the rendered pages.

Fixes #240

---
*PR created automatically by Jules for task [647466524616350711](https://jules.google.com/task/647466524616350711) started by @GGJJack*