### PR TITLE
feat(journal): generate daily report for 2026-05-19

### DIFF
--- a/src/data/journal/2026-05-20-journal.md
+++ b/src/data/journal/2026-05-20-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-20
+agent: journal
+status: completed
+summary: "Generated daily report for 2026-05-19"
+---
+
+## Todo
+- [x] Gather journals from 2026-05-19
+- [x] Create daily report at src/data/updates/2026-05-19-daily.md

--- a/src/data/updates/2026-05-19-daily.md
+++ b/src/data/updates/2026-05-19-daily.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-19
+type: note
+title: 데일리 리포트 · 2026-05-19
+summary: "Google I/O 2026 신규 모델 및 DeepSeek-R1 벤치마크 점수 등 업데이트 반영"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: gemini-3.5-flash, gemini-omni-flash, google-antigravity-2.0, deep-research-max, gemini-3-1-flash-lite-preview (출처: https://blog.google/)
+- 보강: kimi-k2.6 (pricing), deepseek-r1 (pricing), llama-4-maverick-17b (contextWindow), deepseek-v4-pro (releaseDate), exaone-4-5-33b (contextWindow)
+
+### 벤치마크 (collect-benchmark)
+- 점수 추가: deepseek-r1 (출처: https://github.com/deepseek-ai/DeepSeek-R1)
+
+## 상세 페이지 작성 (profile)
+- models/gemini-3.5-flash · status=published
+- models/gemini-omni-flash · status=published
+- benchmarks/osworld-verified · status=published
+- benchmarks/toolathlon · status=published
+- benchmarks/swe-bench-pro · status=published
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 0건
+
+## 미해결 이슈
+- issues/2026-05-19-collect-llm-pricing-missing.md — LLM 가격 정보 누락
+- issues/2026-05-20-profile-benchmark-xlang-ai-org.md — xlang-ai 기관 스텁 생성 필요


### PR DESCRIPTION
This pull request generates the daily update report for 2026-05-19.
It processes the previous day's agent journals and creates `src/data/updates/2026-05-19-daily.md` following the template constraints specified in `skills/journal/SKILL.md`. It also creates today's agent journal `src/data/journal/2026-05-20-journal.md` marked as completed.

---
*PR created automatically by Jules for task [7318422609532298250](https://jules.google.com/task/7318422609532298250) started by @GGJJack*