### PR TITLE
feat(collect-benchmark): register new benchmarks and add gemini 3.5 flash scores

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -294,6 +294,62 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "gdpval-aa",
+      "name": "GDPval-AA",
+      "nameKo": "GDPval-AA",
+      "category": "agent",
+      "description": "에이전트 태스크 해결 능력을 측정하는 ELO 벤치마크",
+      "source": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/",
+      "unit": "Elo",
+      "scoreRange": [
+        0,
+        3000
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "mcp-atlas",
+      "name": "MCP Atlas",
+      "nameKo": "MCP Atlas",
+      "category": "agent",
+      "description": "도구 호출 및 에이전트 능력 평가",
+      "source": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "terminal-bench-2-1",
+      "name": "Terminal-Bench 2.1",
+      "nameKo": "Terminal-Bench 2.1 (터미널 기반 워크플로우 테스트)",
+      "category": "agent",
+      "description": "터미널 환경에서의 에이전트 능력 측정 (버전 2.1)",
+      "source": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "codeforces",
+      "name": "Codeforces",
+      "nameKo": "Codeforces",
+      "category": "coding",
+      "description": "경쟁 프로그래밍 문제 해결 능력을 측정하는 레이팅",
+      "source": "https://api-docs.deepseek.com/news/news260424",
+      "unit": "Rating",
+      "scoreRange": [
+        0,
+        4000
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -1010,6 +1066,26 @@
         "date": "2026-05-19",
         "source": "official",
         "sourceUrl": "https://github.com/deepseek-ai/DeepSeek-R1"
+      }
+    },
+    "gemini-3.5-flash": {
+      "terminal-bench-2-1": {
+        "value": 76.2,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/"
+      },
+      "gdpval-aa": {
+        "value": 1656,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/"
+      },
+      "mcp-atlas": {
+        "value": 83.6,
+        "date": "2026-05-19",
+        "source": "official",
+        "sourceUrl": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/"
       }
     }
   }

--- a/src/data/issues/2026-05-20-collect-benchmark-deepseek-v4-scores.md
+++ b/src/data/issues/2026-05-20-collect-benchmark-deepseek-v4-scores.md
@@ -1,0 +1,16 @@
+---
+created: 2026-05-20
+agent: collect-benchmark
+severity: blocker
+target: llm/deepseek-v4-pro
+---
+
+## 상황  https://api-docs.deepseek.com/news/news260424
+DeepSeek-V4-Pro 및 DeepSeek-V4-Flash 의 공식 벤치마크 점수가 해당 릴리스 노트의 이미지(v4-benchmark.png, v4-benchmark-2.png)로만 제공되며, 텍스트 형태의 정확한 수치를 확인할 수 없음.
+정확한 수치를 텍스트 기반 공식 출처에서 확인하지 못해 점수 입력을 보류함.
+
+## 시도한 것
+릴리스 노트를 확인하였으나 이미지를 통해서만 점수가 공개되어 있어 텍스트 스크래핑으로 추출 불가.
+
+## 요청
+해당 이미지(v4-benchmark.png 등) 내 표를 파싱하거나, 향후 텍스트 기반 공식 기술 보고서(Tech Report) 또는 리더보드를 통해 정확한 점수를 확인하여 MMLU-Pro, GPQA, SWE-bench Verified 등 주요 점수 업데이트 요망.

--- a/src/data/journal/2026-05-20-collect-benchmark.md
+++ b/src/data/journal/2026-05-20-collect-benchmark.md
@@ -1,0 +1,25 @@
+---
+date: 2026-05-20
+agent: collect-benchmark
+status: completed
+summary: "Registered 4 new benchmarks, added Gemini 3.5 Flash scores, and created issue ticket for unreadable DeepSeek V4 scores"
+---
+
+## Todo
+- [x] 신규 벤치마크 정의 등록
+- [x] 모델 × 벤치마크 점수 매칭
+
+## 조사 내역
+- 01:30 Google I/O 2026 발표 내용 및 Gemini 3.5 Flash 벤치마크 점수 확인 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- 01:35 DeepSeek-V4 Pro/Flash 벤치마크 점수 확인 (이미지로만 존재) ← https://api-docs.deepseek.com/news/news260424
+
+## 수행한 작업
+- [x] `gdpval-aa`, `mcp-atlas`, `terminal-bench-2-1`, `codeforces` 벤치마크 등록 (llm 도메인)
+- [x] `gemini-3.5-flash` 의 `terminal-bench-2-1`, `gdpval-aa`, `mcp-atlas` 점수 등록 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+
+## 판단 / 고민
+- Gemini 블로그에 언급된 CharXiv Reasoning은 multimodal 도메인이므로 이번 llm 수집 범위에서 제외함.
+- DeepSeek 공식 릴리스 노트의 벤치마크 점수는 이미지로만 제공되어 정확한 텍스트 기반 수치 확인이 불가능하므로, 오입력 방지를 위해 점수 등록을 생략하고 이슈 티켓을 생성함.
+
+## 이슈 제기
+- issues/2026-05-20-collect-benchmark-deepseek-v4-scores.md


### PR DESCRIPTION
This PR handles the daily `collect-benchmark` task for the LLM domain (2026-05-20). 

It registers four new benchmarks: GDPval-AA, MCP Atlas, Terminal-Bench 2.1, and Codeforces. It also adds the official scores for Gemini 3.5 Flash sourced from the Google I/O 2026 blog post. An issue ticket was created to track the missing DeepSeek V4 scores, as they were only available via images without precise text extraction in the release notes.

---
*PR created automatically by Jules for task [837802265886017034](https://jules.google.com/task/837802265886017034) started by @GGJJack*