### PR TITLE
feat: add benchmark profiles for GDPval-AA, MCP Atlas, and Terminal-Bench 2.1

### DIFF
--- a/src/content/benchmarks/gdpval-aa.md
+++ b/src/content/benchmarks/gdpval-aa.md
@@ -1,0 +1,23 @@
+---
+benchmarkId: gdpval-aa
+domain: llm
+status: draft
+updated: 2026-05-21
+sources:
+  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+highlights:
+  - "44개 직업군 및 9개 주요 산업에 걸친 실제 지식 노동 측정"
+  - "다양한 형태(문서, 슬라이드, 스프레드시트 등)의 실제 업무 산출물 생성 평가"
+  - "Elo 기반 순위 시스템 활용"
+---
+
+# GDPval-AA
+
+## 개요
+GDPval-AA는 44개 직업군 및 9개 주요 산업에 걸쳐 에이전트의 실제 태스크 해결 능력을 측정하는 벤치마크입니다.
+
+## 평가 방법
+모델은 에이전트 루프 내에서 웹 브라우징과 셸 접근 권한을 받아 문서 작성, 재무 제표 분석 등과 같은 업무를 수행하게 되며, 쌍대 비교(pairwise comparisons)를 통해 도출된 Elo 점수로 평가됩니다.
+
+## 한계 및 참고
+해당 평가는 Artificial Analysis 등의 서드파티 평가 기관을 통해 이루어지며, 모델의 실질적인 워크플로우 수행 능력을 평가합니다.

--- a/src/content/benchmarks/mcp-atlas.md
+++ b/src/content/benchmarks/mcp-atlas.md
@@ -1,0 +1,27 @@
+---
+benchmarkId: mcp-atlas
+domain: llm
+status: draft
+updated: 2026-05-21
+sources:
+  - https://arxiv.org/abs/2602.00933
+  - https://scale.com/leaderboard/mcp_atlas
+  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+organization: scale-ai
+paperUrl: https://arxiv.org/abs/2602.00933
+highlights:
+  - "36개 MCP 서버 및 220개 도구 활용 평가"
+  - "1,000개의 다단계 현실 워크플로우 태스크"
+  - "도구 식별, 호출, 구문 검증, 오류 복구 등 포괄적 측정"
+---
+
+# MCP Atlas
+
+## 개요
+MCP Atlas는 언어 모델이 Model Context Protocol (MCP)를 통해 외부 도구를 발견하고 호출하는 역량을 평가하는 대규모 벤치마크입니다. 36개의 실제 MCP 서버와 220개의 도구를 기반으로 현실적이고 다단계인 워크플로우 시나리오를 구성합니다.
+
+## 평가 방법
+단순한 도구 호출이 아닌 올바른 도구를 찾고 매개변수를 조정하며, 에러를 복구하고 결과를 종합하는 능력을 측정합니다. 총 1,000개의 태스크(공개 500개, 비공개 500개)가 제공되며, 태스크 당 3~6회의 도구 호출이 요구됩니다. 평가는 최종 답변의 사실적 만족도(claims-based rubric)를 기준으로 이루어집니다.
+
+## 한계와 비판
+모델이 도구를 효과적으로 사용하지 못하거나 태스크의 의도를 제대로 파악하지 못할 경우 낮은 통과율을 기록할 수 있으며, 이는 모델의 논리적 추론 능력이 뛰어나더라도 실질적인 도구 기반 에이전트 능력에서는 약점을 보일 수 있음을 시사합니다.

--- a/src/content/benchmarks/terminal-bench-2-1.md
+++ b/src/content/benchmarks/terminal-bench-2-1.md
@@ -1,0 +1,26 @@
+---
+benchmarkId: terminal-bench-2-1
+domain: llm
+status: draft
+updated: 2026-05-21
+sources:
+  - https://arxiv.org/abs/2605.12233
+  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+  - https://www.tbench.ai/benchmarks
+paperUrl: https://arxiv.org/abs/2605.12233
+highlights:
+  - "터미널 환경에서 에이전트의 자율적 태스크 해결 능력 측정"
+  - "소프트웨어 엔지니어링, 머신러닝, 시스템 관리 등 다양한 도메인 포함"
+  - "환경 내 지시사항의 맥락적 이해 및 우선순위 판단 능력 평가"
+---
+
+# Terminal-Bench 2.1
+
+## 개요
+Terminal-Bench 2.1은 에이전트가 터미널 환경에서 자율적으로 작업을 수행하는 능력을 측정하는 벤치마크입니다. 소프트웨어 개발, 데이터 사이언스, 보안 등 다방면에 걸친 태스크를 제공하여 모델의 도구 활용과 문제 해결 능력을 검증합니다.
+
+## 평가 방법
+모델은 주어진 터미널 인터페이스를 이용해 종속성 설치, 명령어 실행, 파일 수정 등의 과정을 반복하며 문제를 해결해야 합니다. 환경 내에 존재하는 README, 코드 주석 등 다양한 컨텍스트를 올바르게 해석하고 유효한 지시사항만을 선별해 따르는 역량(Task Alignment)을 중점적으로 평가합니다.
+
+## 한계와 비판
+기존 벤치마크들은 모델이 불필요한 단서까지 맹목적으로 따르거나 아예 무시하는 행동 패턴을 충분히 걸러내지 못하는 한계가 지적되었습니다. 이에 파생된 TAB(Task Alignment Benchmark) 연구는 에이전트가 필수적인 단서와 방해 요소(distractor)를 어떻게 구분하고 대처하는지를 더욱 정밀하게 측정하려는 시도를 보여줍니다.

--- a/src/data/issues/2026-05-21-profile-benchmark-gdpval-aa-org.md
+++ b/src/data/issues/2026-05-21-profile-benchmark-gdpval-aa-org.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-21
+agent: profile-benchmark
+severity: minor
+target: llm/gdpval-aa
+---
+
+# GDPval-AA 기관 상세 조사 필요
+
+gdpval-aa 벤치마크에 대한 조직 ID 및 세부 정보를 확인하지 못했습니다. 기관 조사가 필요합니다.

--- a/src/data/issues/2026-05-21-profile-benchmark-terminal-bench-2-1-org.md
+++ b/src/data/issues/2026-05-21-profile-benchmark-terminal-bench-2-1-org.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-21
+agent: profile-benchmark
+severity: minor
+target: llm/terminal-bench-2-1
+---
+
+# Terminal-Bench 2.1 기관 상세 조사 필요
+
+terminal-bench-2-1 벤치마크에 대한 조직 ID 및 세부 정보를 확인하지 못했습니다. 기관 조사가 필요합니다.

--- a/src/data/journal/2026-05-20-profile-benchmark.md
+++ b/src/data/journal/2026-05-20-profile-benchmark.md
@@ -1,0 +1,16 @@
+---
+date: 2026-05-20
+agent: profile-benchmark
+status: completed
+---
+
+# profile-benchmark
+
+## Todo
+- [x] llm 도메인 벤치마크 (gdpval-aa, mcp-atlas, terminal-bench-2-1) 상세 페이지 작성
+
+## 이어서 (02:30)
+
+- `src/content/benchmarks/gdpval-aa.md` 작성 완료 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- `src/content/benchmarks/mcp-atlas.md` 작성 완료 ← https://arxiv.org/abs/2602.00933, https://scale.com/leaderboard/mcp_atlas, https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- `src/content/benchmarks/terminal-bench-2-1.md` 작성 완료 ← https://arxiv.org/abs/2605.12233, https://www.tbench.ai/benchmarks, https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/


### PR DESCRIPTION
This PR creates detailed Markdown profiles for three agentic benchmarks (`gdpval-aa`, `mcp-atlas`, `terminal-bench-2-1`) recently added to the LLM domain collection.

Since exact organization details for GDPval-AA and Terminal-Bench 2.1 could not be fully verified without guessing, I opted to omit the `organization` field and generated the requisite issue tickets to have them resolved manually according to our Groundedness rules.

The journal has been updated, and `bun run build` verifies everything aligns with the frontmatter schemas.

---
*PR created automatically by Jules for task [6067426249619309782](https://jules.google.com/task/6067426249619309782) started by @GGJJack*