### PR TITLE
feat(journal): publish 2026-05-20 daily report

### DIFF
--- a/src/data/journal/2026-05-21-journal.md
+++ b/src/data/journal/2026-05-21-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-21
+agent: journal
+status: completed
+summary: "Published daily report for 2026-05-20"
+---
+
+## 수행한 작업
+- [x] 전일(2026-05-20) `collect-benchmark`, `profile-benchmark`, `profile-model` 저널 취합 후 요약 정리.
+- [x] `src/data/updates/2026-05-20-daily.md` 데일리 리포트 발행 완료.

--- a/src/data/updates/2026-05-20-daily.md
+++ b/src/data/updates/2026-05-20-daily.md
@@ -1,0 +1,27 @@
+---
+date: 2026-05-20
+type: note
+title: 데일리 리포트 · 2026-05-20
+summary: "신규 벤치마크 4건 등록, Gemini 3.5 Flash 점수 등록, Google 신규 모델 및 Kimi K2.5 상세 페이지 작성"
+---
+
+## 오늘의 수집
+
+### 벤치마크 (collect-benchmark)
+- 신규 등록: `gdpval-aa`, `mcp-atlas`, `terminal-bench-2-1`, `codeforces` 벤치마크 (llm 도메인)
+- 점수 등록: `gemini-3.5-flash` 의 `terminal-bench-2-1`, `gdpval-aa`, `mcp-atlas` 점수 등록 (출처: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/)
+
+## 상세 페이지 작성 (profile)
+
+### 프로파일 벤치마크 (profile-benchmark)
+- `src/content/benchmarks/gdpval-aa.md` 작성 완료
+- `src/content/benchmarks/mcp-atlas.md` 작성 완료
+- `src/content/benchmarks/terminal-bench-2-1.md` 작성 완료
+
+### 프로파일 모델 (profile-model)
+- `src/content/models/google-antigravity-2.0.md` 생성 (status: published)
+- `src/content/models/deep-research-max.md` 생성 (status: published)
+- `src/content/models/kimi-k2.5.md` 업데이트 (status: published)
+
+## 미해결 이슈
+- issues/2026-05-20-collect-benchmark-deepseek-v4-scores.md — DeepSeek V4 Pro/Flash 벤치마크 점수 확인 불가 (이미지로만 제공)


### PR DESCRIPTION
This PR fulfills the automated `journal` task for KST 2026-05-21 05:00.

It reads the agent journals from "yesterday" (2026-05-20):
- `collect-benchmark`
- `profile-benchmark`
- `profile-model`

It aggregates their activities and metrics without hallucination into a single daily report `src/data/updates/2026-05-20-daily.md` according to the template in `SKILL.md`.

Finally, it marks the completion of its own task in `src/data/journal/2026-05-21-journal.md` with a `completed` status. Validation was performed using `bun run build`.

---
*PR created automatically by Jules for task [16692670186540292700](https://jules.google.com/task/16692670186540292700) started by @GGJJack*