### PR TITLE
feat: run collect-benchmark cycle and track missing scores (2026-05-21)

### DIFF
--- a/src/data/issues/2026-05-22-collect-benchmark-deep-research-max.md
+++ b/src/data/issues/2026-05-22-collect-benchmark-deep-research-max.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-22
+agent: collect-benchmark
+severity: minor
+target: llm/deep-research-max
+---
+
+## 상황
+`deep-research-max` 모델의 벤치마크 점수를 수집하려 했으나, 공식 블로그(https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/)의 벤치마크 수치가 이미지로만 제공되어 추출이 불가능함.
+
+## 시도한 것
+공식 블로그 본문 스크래핑을 시도했으나 차트 이미지의 `alt-text` 로만 간략한 요약이 존재할 뿐 명확한 수치가 없어 미등록 처리함.
+
+## 요청
+`deep-research-max` 의 텍스트 기반 공식 벤치마크 점수가 포함된 문서(PDF, 기술 리포트 등)가 제공되면 점수들을 등록해 주세요.

--- a/src/data/issues/2026-05-22-collect-benchmark-gemini-3-1-flash-lite-preview.md
+++ b/src/data/issues/2026-05-22-collect-benchmark-gemini-3-1-flash-lite-preview.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-22
+agent: collect-benchmark
+severity: minor
+target: llm/gemini-3-1-flash-lite-preview
+---
+
+## 상황
+`gemini-3-1-flash-lite-preview` 모델의 벤치마크 점수 수집을 시도했으나, 관련 공식 출처에서 벤치마크 점수를 확인할 수 없음.
+
+## 시도한 것
+Google 관련 발표 자료 및 블로그 내 벤치마크 수치 검색을 시도했으나 해당 모델에 대한 구체적인 점수 기록이 없어 등록을 보류함.
+
+## 요청
+추후 `gemini-3-1-flash-lite-preview` 의 벤치마크 점수가 포함된 공식 문서가 발견되면 점수를 수집하여 등록해 주세요.

--- a/src/data/issues/2026-05-22-collect-benchmark-gemini-omni-flash.md
+++ b/src/data/issues/2026-05-22-collect-benchmark-gemini-omni-flash.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-22
+agent: collect-benchmark
+severity: minor
+target: llm/gemini-omni-flash
+---
+
+## 상황
+`gemini-omni-flash` 모델의 벤치마크 점수 수집을 시도했으나, 공식 블로그(https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni/)에서 명확한 텍스트 기반의 표준 벤치마크 점수를 찾을 수 없음.
+
+## 시도한 것
+공식 블로그의 본문 및 테이블 분석. 수치형 벤치마크 데이터가 부족하여 점수를 추출하지 못함.
+
+## 요청
+공식 문서나 기술 보고서(Technical Report)가 추가로 공개되면, `gemini-omni-flash` 모델의 주요 벤치마크 점수(MMLU, HumanEval 등)를 찾아 `llm.json`에 `official` 출처로 등록해 주세요.

--- a/src/data/issues/2026-05-22-collect-benchmark-google-antigravity-2-0.md
+++ b/src/data/issues/2026-05-22-collect-benchmark-google-antigravity-2-0.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-22
+agent: collect-benchmark
+severity: minor
+target: llm/google-antigravity-2-0
+---
+
+## 상황
+`google-antigravity-2.0` 모델의 공식 벤치마크 점수가 확인되지 않음. Google I/O 2026 발표 내용 및 연관 블로그에서 구체적인 벤치마크 수치를 추출할 수 없음.
+
+## 시도한 것
+Google 블로그 및 검색을 통한 벤치마크 점수 확인 시도. 명확한 수치 부재로 미등록 처리.
+
+## 요청
+`google-antigravity-2.0` 모델의 벤치마크 점수가 명시된 공식 기술 보고서 또는 문서가 나오면, 해당 점수를 등록해 주세요.

--- a/src/data/journal/2026-05-21-collect-benchmark.md
+++ b/src/data/journal/2026-05-21-collect-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-05-21
+agent: collect-benchmark
+status: completed
+summary: "Checked for new benchmark scores of recent Google models and generated issue tickets for missing or unparsable scores"
+---
+
+## Todo
+- [x] 신규 모델(Gemini Omni, Deep Research Max 등)의 벤치마크 점수 등록
+- [x] 점수 확인 불가/출처 불명 시 이슈 티켓 생성
+
+## 조사 내역
+- 01:30 Google I/O 2026 발표 내용 및 Gemini Omni Flash 공식 블로그 확인 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni/
+- 01:35 Deep Research Max 공식 블로그 확인 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/
+
+## 수행한 작업
+- `collect-llm` 사이클에서 새로 등록된 `gemini-omni-flash`, `google-antigravity-2.0`, `deep-research-max`, `gemini-3-1-flash-lite-preview` 의 점수 매칭 시도.
+- 공식 블로그에서 명확한 텍스트 기반의 점수(MMLU, HumanEval 등)를 찾을 수 없고 일부는 이미지로만 존재함을 확인하여 점수 등록 보류.
+
+## 판단 / 고민
+- 새로운 Google 모델들의 벤치마크 점수가 텍스트 형태로 명시되어 있지 않거나 공식 리포트가 나오지 않음. 출처 URL 없이 점수를 추정하거나 이미지에 의존하여 오입력할 위험이 있어 `AGENTS.md` 규정에 따라 저장하지 않음.
+- 해당 모델들에 대해 개별적으로 `reinforce` 에이전트가 추후 보강할 수 있도록 이슈 티켓을 생성함.
+
+## 이슈 제기
+- issues/2026-05-22-collect-benchmark-gemini-omni-flash.md
+- issues/2026-05-22-collect-benchmark-google-antigravity-2-0.md
+- issues/2026-05-22-collect-benchmark-deep-research-max.md
+- issues/2026-05-22-collect-benchmark-gemini-3-1-flash-lite-preview.md


### PR DESCRIPTION
This PR runs the daily `collect-benchmark` cycle for the `llm` domain (date: `2026-05-21` UTC). \n\nIt checks newly registered Google models (`gemini-omni-flash`, `google-antigravity-2.0`, `deep-research-max`, `gemini-3-1-flash-lite-preview`) for their benchmark scores. Since the official sources only provided scores as unparsable images or did not list standard text-based benchmark numbers, it generated the corresponding issue tickets for `reinforce` tasks to address later, fully complying with the `AGENTS.md` guidelines.

---
*PR created automatically by Jules for task [13063877855862972794](https://jules.google.com/task/13063877855862972794) started by @GGJJack*