### PR TITLE
Register new models and reinforce metadata (2026-05-21)

### DIFF
--- a/src/data/journal/2026-05-21-collect-llm.md
+++ b/src/data/journal/2026-05-21-collect-llm.md
@@ -1,0 +1,42 @@
+---
+status: completed
+skill: collect-llm
+date: 2026-05-21
+---
+
+# Journal - 2026-05-21 (collect-llm)
+
+## Tasks
+- [x] Scan for new LLM models (Focus: Major players + Korea/Japan/China)
+- [x] Reinforce existing models with null fields
+- [x] Record changes in this journal
+
+## Scan Results
+- New Models Found (via Bedrock/Google blog):
+    - Amazon Nova 2 Omni
+    - Amazon Nova 2 Pro
+    - Mistral Voxtral Mini 1.0
+    - Mistral Voxtral Small 1.0
+
+## Actions
+- Registered `amazon-nova-2-omni`:
+    - pricing ← https://aws.amazon.com/bedrock/pricing/
+    - contextWindow ← https://aws.amazon.com/bedrock/pricing/
+- Registered `amazon-nova-2-pro`:
+    - pricing ← https://aws.amazon.com/bedrock/pricing/
+    - contextWindow ← https://aws.amazon.com/bedrock/pricing/
+- Registered `voxtral-mini-1-0`:
+    - pricing ← https://aws.amazon.com/bedrock/pricing/
+    - contextWindow ← https://aws.amazon.com/bedrock/pricing/
+- Registered `voxtral-small-1-0`:
+    - pricing ← https://aws.amazon.com/bedrock/pricing/
+    - contextWindow ← https://aws.amazon.com/bedrock/pricing/
+- Updated `google-antigravity-2.0`:
+    - pricing ← https://ai.google.dev/pricing
+    - contextWindow ← https://ai.google.dev/pricing
+- Updated `gemini-omni-flash`:
+    - pricing ← https://ai.google.dev/pricing
+    - contextWindow ← https://ai.google.dev/pricing
+- Updated `deep-research-max`:
+    - pricing ← https://ai.google.dev/pricing
+    - contextWindow ← https://ai.google.dev/pricing

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -1606,8 +1606,11 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": null,
-      "pricing": null,
+      "contextWindow": 1048576,
+      "pricing": {
+        "input": 1.5,
+        "output": 9
+      },
       "links": {
         "official": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni/"
       },
@@ -1619,8 +1622,11 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": null,
-      "pricing": null,
+      "contextWindow": 1048576,
+      "pricing": {
+        "input": 1.5,
+        "output": 9
+      },
       "links": {
         "official": "https://antigravity.google/blog/introducing-google-antigravity-2-0"
       },
@@ -1632,8 +1638,11 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": null,
-      "pricing": null,
+      "contextWindow": 1048576,
+      "pricing": {
+        "input": 2,
+        "output": 12
+      },
       "links": {
         "official": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/"
       },
@@ -1657,6 +1666,70 @@
       "name": "Gemini 3.1 Flash-Lite Preview",
       "provider": "Google",
       "releaseDate": "2026-05-18",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 1000000,
+      "pricing": {
+        "input": 0.6,
+        "output": 1.2
+      },
+      "links": {
+        "official": "https://aws.amazon.com/bedrock/pricing/"
+      },
+      "id": "amazon-nova-2-omni",
+      "name": "Amazon Nova 2 Omni",
+      "provider": "Amazon",
+      "releaseDate": "2026-05-19",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 1000000,
+      "pricing": {
+        "input": 0.8,
+        "output": 2.4
+      },
+      "links": {
+        "official": "https://aws.amazon.com/bedrock/pricing/"
+      },
+      "id": "amazon-nova-2-pro",
+      "name": "Amazon Nova 2 Pro",
+      "provider": "Amazon",
+      "releaseDate": "2026-05-19",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 128000,
+      "pricing": {
+        "input": 0.04,
+        "output": 0.04
+      },
+      "links": {
+        "official": "https://aws.amazon.com/bedrock/pricing/"
+      },
+      "id": "voxtral-mini-1-0",
+      "name": "Voxtral Mini 1.0",
+      "provider": "Mistral AI",
+      "releaseDate": "2026-05-19",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 128000,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
+      "links": {
+        "official": "https://aws.amazon.com/bedrock/pricing/"
+      },
+      "id": "voxtral-small-1-0",
+      "name": "Voxtral Small 1.0",
+      "provider": "Mistral AI",
+      "releaseDate": "2026-05-19",
       "license": "Proprietary"
     }
   ]


### PR DESCRIPTION
This task involved scanning for new LLM releases and reinforcing metadata for existing models.

Newly registered:
- Amazon Nova 2 Omni ($0.6/$1.2, 1M context)
- Amazon Nova 2 Pro ($0.8/$2.4, 1M context)
- Mistral Voxtral Mini 1.0 ($0.04/$0.04, 128k context)
- Mistral Voxtral Small 1.0 ($0.1/$0.3, 128k context)

Reinforced:
- Google Antigravity 2.0 (Pricing: $1.5/$9.0, Context: 1,048,576)
- Gemini Omni Flash (Pricing: $1.5/$9.0, Context: 1,048,576)
- Deep Research Max (Pricing: $2.0/$12.0, Context: 1,048,576)

All changes were verified using CLI tools, Astro build, and frontend screenshots.

Fixes #254

---
*PR created automatically by Jules for task [16702590214564634940](https://jules.google.com/task/16702590214564634940) started by @GGJJack*