### PR TITLE
feat(journal): publish daily report for 2026-05-21

### DIFF
--- a/src/data/journal/2026-05-22-journal.md
+++ b/src/data/journal/2026-05-22-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-22
+agent: journal
+status: completed
+summary: "Published daily report for 2026-05-21"
+---
+
+## 수행한 작업
+- [x] 전일(2026-05-21) `collect-benchmark`, `collect-llm`, `profile-model` 저널 취합 후 요약 정리.
+- [x] `src/data/updates/2026-05-21-daily.md` 데일리 리포트 발행 완료.

--- a/src/data/updates/2026-05-21-daily.md
+++ b/src/data/updates/2026-05-21-daily.md
@@ -1,0 +1,31 @@
+---
+date: 2026-05-21
+type: note
+title: 데일리 리포트 · 2026-05-21
+summary: "신규 Google/Amazon 모델 4건 및 업데이트 3건 수집, DeepSeek V4 시리즈 상세 페이지 발행, 신규 Google 모델 벤치마크 점수 누락에 따른 이슈 4건 생성"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: amazon-nova-2-omni (https://aws.amazon.com/bedrock/pricing/)
+- 신규: amazon-nova-2-pro (https://aws.amazon.com/bedrock/pricing/)
+- 신규: voxtral-mini-1-0 (https://aws.amazon.com/bedrock/pricing/)
+- 신규: voxtral-small-1-0 (https://aws.amazon.com/bedrock/pricing/)
+- 보강: google-antigravity-2.0 · pricing, contextWindow
+- 보강: gemini-omni-flash · pricing, contextWindow
+- 보강: deep-research-max · pricing, contextWindow
+
+### 벤치마크 (collect-benchmark)
+- 신규 Google 모델(Gemini Omni Flash, Deep Research Max 등)의 벤치마크 점수 등록 시도 (https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni/, https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/)
+- 명확한 텍스트 기반 점수 확인 불가로 등록 보류 후 이슈 생성
+
+## 상세 페이지 작성 (profile)
+- models/deepseek-v4-pro · status=published
+- models/deepseek-v4-flash · status=published
+
+## 미해결 이슈
+- issues/2026-05-22-collect-benchmark-gemini-omni-flash.md — 점수 텍스트 명시 부족으로 등록 보류
+- issues/2026-05-22-collect-benchmark-google-antigravity-2-0.md — 점수 텍스트 명시 부족으로 등록 보류
+- issues/2026-05-22-collect-benchmark-deep-research-max.md — 점수 텍스트 명시 부족으로 등록 보류
+- issues/2026-05-22-collect-benchmark-gemini-3-1-flash-lite-preview.md — 점수 텍스트 명시 부족으로 등록 보류


### PR DESCRIPTION
This PR automatically publishes the daily report for `2026-05-21` based on the previous day's agent journals. It also creates a completed journal entry for the `journal` task on `2026-05-22`. All validations passed via `bun run build`.

---
*PR created automatically by Jules for task [7582380010600114813](https://jules.google.com/task/7582380010600114813) started by @GGJJack*