### PR TITLE
collect-benchmark: create issue tickets for new LLM models without text scores

### DIFF
--- a/src/data/issues/2026-05-23-collect-benchmark-amazon-nova-2-omni.md
+++ b/src/data/issues/2026-05-23-collect-benchmark-amazon-nova-2-omni.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-23
+agent: collect-benchmark
+severity: minor
+target: llm/amazon-nova-2-omni
+---
+
+## 상황
+Amazon Bedrock pricing 등에서 신규 모델 `amazon-nova-2-omni` 의 존재를 확인했으나, 공식 문서에서 LLM 벤치마크 점수(MMLU 등)에 대한 명시적인 텍스트 기록을 찾을 수 없음.
+
+## 시도한 것
+- Google 검색 및 AWS 블로그, CloudPrice 등을 확인했으나 공식적/신뢰할 수 있는 텍스트 형태의 점수표 부재.
+
+## 요청
+`amazon-nova-2-omni` 모델의 공식적인 LLM 벤치마크 점수 발표 여부를 추가 확인하고, 가능한 경우 등록.

--- a/src/data/issues/2026-05-23-collect-benchmark-amazon-nova-2-pro.md
+++ b/src/data/issues/2026-05-23-collect-benchmark-amazon-nova-2-pro.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-23
+agent: collect-benchmark
+severity: minor
+target: llm/amazon-nova-2-pro
+---
+
+## 상황
+Amazon Bedrock pricing 등에서 신규 모델 `amazon-nova-2-pro` 의 존재를 확인했으나, 공식 문서에서 LLM 벤치마크 점수(MMLU 등)에 대한 명시적인 텍스트 기록을 찾을 수 없음.
+
+## 시도한 것
+- Google 검색 및 AWS 블로그 등을 확인했으나 공식적/신뢰할 수 있는 텍스트 형태의 점수표 부재.
+
+## 요청
+`amazon-nova-2-pro` 모델의 공식적인 LLM 벤치마크 점수 발표 여부를 추가 확인하고, 가능한 경우 등록.

--- a/src/data/issues/2026-05-23-collect-benchmark-voxtral-mini-1-0.md
+++ b/src/data/issues/2026-05-23-collect-benchmark-voxtral-mini-1-0.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-23
+agent: collect-benchmark
+severity: minor
+target: llm/voxtral-mini-1-0
+---
+
+## 상황
+최근 수집된 신규 모델 `voxtral-mini-1-0` (Mistral AI) 에 대한 범용 LLM 벤치마크 점수 부재. 오디오/음성 인식(FLEURS 등) 지표는 존재하나 llm 도메인 벤치마크 기준 점수가 확인되지 않음.
+
+## 시도한 것
+- HuggingFace 및 Mistral AI 웹사이트, AWS Bedrock 정보 확인.
+
+## 요청
+`voxtral-mini-1-0` 모델의 공식적인 범용 LLM 벤치마크 (MMLU 등) 존재 여부 확인 후 등록 필요.

--- a/src/data/issues/2026-05-23-collect-benchmark-voxtral-small-1-0.md
+++ b/src/data/issues/2026-05-23-collect-benchmark-voxtral-small-1-0.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-23
+agent: collect-benchmark
+severity: minor
+target: llm/voxtral-small-1-0
+---
+
+## 상황
+최근 수집된 신규 모델 `voxtral-small-1-0` (Mistral AI) 에 대한 범용 LLM 벤치마크 점수 부재.
+
+## 시도한 것
+- HuggingFace 및 Mistral AI 공식 정보, AWS Bedrock 문서를 검색하였으나 해당 모델에 대한 텍스트 형태의 LLM 기준 점수표를 찾지 못함.
+
+## 요청
+`voxtral-small-1-0` 모델의 공식적인 범용 LLM 벤치마크 존재 여부 확인 후 점수 등록 필요.

--- a/src/data/journal/2026-05-22-collect-benchmark.md
+++ b/src/data/journal/2026-05-22-collect-benchmark.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-22
+agent: collect-benchmark
+status: completed
+summary: "Checked for new benchmark scores of recently discovered Amazon Nova 2 and Mistral Voxtral models and generated issue tickets for missing or unparsable scores"
+---
+
+## Todo
+- [x] 신규 모델(`amazon-nova-2-omni`, `amazon-nova-2-pro`, `voxtral-mini-1-0`, `voxtral-small-1-0`)의 벤치마크 점수 등록 여부 조사
+- [x] 점수 확인 불가/출처 불명 시 이슈 티켓 생성
+
+## 조사 내역
+- 01:30 AWS 블로그 및 Bedrock Pricing 문서 등을 탐색하여 신규 Amazon Nova 2 및 Mistral Voxtral 모델들의 점수 확인 시도 ← https://aws.amazon.com/bedrock/pricing/
+- 01:35 HuggingFace 및 관련 커뮤니티 등을 통한 벤치마크 지표 탐색.
+
+## 수행한 작업
+- `collect-llm` 사이클에서 새로 등록된 `amazon-nova-2-omni`, `amazon-nova-2-pro`, `voxtral-mini-1-0`, `voxtral-small-1-0` 의 벤치마크 점수 매칭 시도.
+- 공식 문서/블로그 등에서 명확한 텍스트 기반의 범용 LLM 점수(MMLU, HumanEval 등)를 찾을 수 없음을 확인하여 점수 등록 보류.
+
+## 판단 / 고민
+- 새로운 모델들에 대한 벤치마크 점수가 텍스트 형태로 명확하게 제공되지 않거나, 아직 범용 LLM 지표가 충분히 문서화되지 않았음.
+- 추정하거나 비공식/검증되지 않은 출처에 의존하여 오입력할 위험이 있어 `AGENTS.md` 규정에 따라 벤치마크 데이터를 저장하지 않음.
+- 대신 `reinforce` 에이전트가 추후 보강할 수 있도록 개별 이슈 티켓을 생성함.
+
+## 이슈 제기
+- issues/2026-05-23-collect-benchmark-amazon-nova-2-omni.md
+- issues/2026-05-23-collect-benchmark-amazon-nova-2-pro.md
+- issues/2026-05-23-collect-benchmark-voxtral-mini-1-0.md
+- issues/2026-05-23-collect-benchmark-voxtral-small-1-0.md


### PR DESCRIPTION
This PR executes the `collect-benchmark` task for the current cycle.

We detected four new models recently discovered by `collect-llm`:
- `amazon-nova-2-omni`
- `amazon-nova-2-pro`
- `voxtral-mini-1-0`
- `voxtral-small-1-0`

Following `AGENTS.md` and the `collect-benchmark` rules, unverified and non-textual benchmark scores must not be guessed or registered to prevent hallucination. As authoritative, textual LLM benchmark data is not yet clearly available for these models, we generated the corresponding issue tickets for `reinforce` to handle in the future and logged the findings in today's UTC journal (`2026-05-22-collect-benchmark.md`).

---
*PR created automatically by Jules for task [16276850890286827552](https://jules.google.com/task/16276850890286827552) started by @GGJJack*