### PR TITLE
Publish 2026-05-22 Daily Report

### DIFF
--- a/src/data/journal/2026-05-23-journal.md
+++ b/src/data/journal/2026-05-23-journal.md
@@ -1,0 +1,10 @@
+---
+date: 2026-05-23
+agent: journal
+status: completed
+summary: "Published daily report for 2026-05-22"
+---
+
+## 수행한 작업
+- [x] 전일(2026-05-22) `collect-benchmark`, `collect-llm`, `profile-model`, `profile-benchmark` 저널 취합 후 요약 정리.
+- [x] `src/data/updates/2026-05-22-daily.md` 데일리 리포트 발행 완료.

--- a/src/data/updates/2026-05-22-daily.md
+++ b/src/data/updates/2026-05-22-daily.md
@@ -1,0 +1,33 @@
+---
+date: 2026-05-22
+type: note
+title: 데일리 리포트 · 2026-05-22
+summary: "총 2건의 신규 모델, 2건의 모델 보강 및 3건의 벤치마크 업데이트가 처리되었습니다."
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: command-a-plus-05-2026 (https://cohere.com/blog/command-a-plus)
+- 신규: granite-4.1-30b, 8b, 3b (https://www.ibm.com/granite/docs/models/granite4-1)
+- 보강: llama-4-scout-17b contextWindow · (10,000,000)
+- 보강: grok-4.1-fast pricing · ($0.2/$0.5)
+
+### 벤치마크 (collect-benchmark)
+- 확인 불가: `collect-llm` 사이클에서 새로 등록된 `amazon-nova-2-omni`, `amazon-nova-2-pro`, `voxtral-mini-1-0`, `voxtral-small-1-0` (이슈 제기됨)
+
+## 상세 페이지 작성 (profile)
+- models/command-a-plus-05-2026 · status=published
+- models/granite-4.1-30b · status=published
+- benchmarks/codeforces · status=published
+- benchmarks/mbpp · status=published
+- benchmarks/arc-c · status=published
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 4건
+
+## 미해결 이슈
+- issues/2026-05-23-collect-benchmark-amazon-nova-2-omni.md
+- issues/2026-05-23-collect-benchmark-amazon-nova-2-pro.md
+- issues/2026-05-23-collect-benchmark-voxtral-mini-1-0.md
+- issues/2026-05-23-collect-benchmark-voxtral-small-1-0.md


### PR DESCRIPTION
Published the daily report for 2026-05-22, dynamically extracting all numbers, tasks, and issues directly from yesterday's agent journals (`collect-*`, `profile-*`, `reinforce`). Also added the daily `journal` agent run completion file for 2026-05-23.

---
*PR created automatically by Jules for task [90499800640767508](https://jules.google.com/task/90499800640767508) started by @GGJJack*