### PR TITLE
feat(benchmark): profile trivia-qa and create university-of-washington stub

### DIFF
--- a/src/content/benchmarks/trivia-qa.md
+++ b/src/content/benchmarks/trivia-qa.md
@@ -1,20 +1,27 @@
 ---
 benchmarkId: trivia-qa
 domain: llm
-status: draft
-updated: 2026-05-13
+status: published
+updated: 2026-05-23
 sources:
-  - https://arxiv.org/abs/1705.03551
-paperUrl: https://arxiv.org/abs/1705.03551
+  - "https://arxiv.org/abs/1705.03551"
+  - "http://nlp.cs.washington.edu/triviaqa/"
+  - "https://en.wikipedia.org/wiki/University_of_Washington"
+organization: university-of-washington
+paperUrl: "https://arxiv.org/abs/1705.03551"
 highlights:
   - "650K개 이상의 질문-답변-증거 트리플 포함"
   - "위키피디아 및 웹 데이터 기반의 독해 및 상식 평가"
+  - "트리비아 애호가들이 작성한 고품질 데이터셋"
 ---
 
 # TriviaQA
 
 ## 개요
-TriviaQA는 위키피디아 및 웹 데이터를 기반으로 한 대규모 독해 및 상식 평가 벤치마크이다. 트리비아 애호가들이 작성한 95K개의 질문-답변 쌍과 질문당 평균 6개의 독립적으로 수집된 증거 문서를 포함하여, 총 650K개 이상의 질문-답변-증거 트리플을 제공한다.
+TriviaQA는 위키피디아 및 웹 데이터를 기반으로 한 대규모 독해 및 상식 평가 벤치마크이다. 트리비아 애호가들이 작성한 95K개의 질문-답변 쌍과 질문당 평균 6개의 독립적으로 수집된 증거 문서를 포함하여, 총 650K개 이상의 질문-답변-증거 트리플을 제공한다. University of Washington 연구진에 의해 2017년에 발표되었다.
 
 ## 평가 방법
-비교적 복잡하고 구성적인 질문들을 특징으로 하며, 질문과 정답-증거 문장 간의 구문론적, 어휘적 다양성이 크다. 정답을 찾기 위해 여러 문장을 교차 추론해야 하는 과제를 제시한다.
+비교적 복잡하고 구성적인 질문들을 특징으로 하며, 질문과 정답-증거 문장 간의 구문론적, 어휘적 다양성이 크다. 정답을 찾기 위해 여러 문장을 교차 추론해야 하는 과제를 제시한다. 오픈 도메인 질문 응답(Open-domain QA) 및 기계 독해(Reading Comprehension) 모델의 성능을 평가하는 데 널리 사용된다.
+
+## 점수 해석
+주로 정확도(Accuracy) 지표를 사용하여 평가하며, Exact Match (EM) 및 F1 Score를 통해 모델의 예측 답변이 정답과 얼마나 일치하는지를 측정한다. 점수가 높을수록(Higher is Better) 더 복잡한 문맥에서 상식과 독해 능력을 잘 발휘하는 우수한 모델임을 의미한다.

--- a/src/content/organizations/university-of-washington.md
+++ b/src/content/organizations/university-of-washington.md
@@ -1,0 +1,13 @@
+---
+orgId: university-of-washington
+name: University of Washington
+type: academic
+status: draft
+updated: 2026-05-23
+sources:
+  - "http://nlp.cs.washington.edu/triviaqa/"
+  - "https://en.wikipedia.org/wiki/University_of_Washington"
+---
+
+# University of Washington
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-05-24-profile-benchmark-trivia-qa-org.md
+++ b/src/data/issues/2026-05-24-profile-benchmark-trivia-qa-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-24
+agent: profile-benchmark
+severity: minor
+target: organization/university-of-washington
+---
+--
+## 상황
+university-of-washington 기관 상세 페이지 스텁이 생성되었으나 정보가 부족함.
+
+## 시도한 것
+기본적인 기관 스텁 파일(`src/content/organizations/university-of-washington.md`) 생성.
+
+## 요청
+해당 기관의 추가적인 개요 설명 보강 요망.

--- a/src/data/journal/2026-05-23-profile-benchmark.md
+++ b/src/data/journal/2026-05-23-profile-benchmark.md
@@ -1,0 +1,20 @@
+---
+date: 2026-05-23
+agent: profile-benchmark
+status: completed
+summary: "TriviaQA 상세 페이지 작성 및 university-of-washington 기관 스텁 생성"
+---
+--
+## Todo
+- [ ] TriviaQA 페이지 작성 및 university-of-washington 스텁 생성
+## 조사 내역
+- 03:02  TriviaQA 개요 및 내용 파악  ← https://arxiv.org/abs/1705.03551
+- 03:03  TriviaQA 제작 기관 및 데이터 다운로드 확인  ← http://nlp.cs.washington.edu/triviaqa/
+- 03:04  University of Washington 정보 확인  ← https://en.wikipedia.org/wiki/University_of_Washington
+## 수행한 작업
+- [x] TriviaQA 상세 페이지 내용 작성 및 published 승격  ← https://arxiv.org/abs/1705.03551
+- [x] university-of-washington 스텁 생성 및 이슈 티켓 발행
+## 판단 / 고민
+- TriviaQA 페이지를 구체화하여 3단락 이상의 내용을 확보.
+## 이슈 제기
+- issues/2026-05-24-profile-benchmark-trivia-qa-org.md


### PR DESCRIPTION
This PR updates the `trivia-qa` benchmark to a published state with verified information, creates a stub for its organization `university-of-washington`, and adds an issue ticket to further expand on the organization page later. It also correctly updates the task's journal.

---
*PR created automatically by Jules for task [10953771790007364980](https://jules.google.com/task/10953771790007364980) started by @GGJJack*