### PR TITLE
Update Codeforces, Scale AI organizations and MCP Atlas profile

### DIFF
--- a/src/content/benchmarks/mcp-atlas.md
+++ b/src/content/benchmarks/mcp-atlas.md
@@ -1,7 +1,7 @@
 ---
 benchmarkId: mcp-atlas
 domain: llm
-status: draft
+status: published
 updated: 2026-05-21
 sources:
   - https://arxiv.org/abs/2602.00933

--- a/src/content/organizations/codeforces.md
+++ b/src/content/organizations/codeforces.md
@@ -3,10 +3,18 @@ orgId: codeforces
 name: Codeforces
 type: community
 status: draft
-updated: 2026-05-22
+updated: 2026-05-25
 sources:
-  - "https://en.wikipedia.org/wiki/Codeforces"
+  - https://en.wikipedia.org/wiki/Codeforces
 ---
 
 # Codeforces
-경쟁 프로그래밍 플랫폼 Codeforces를 운영하는 단체/커뮤니티입니다.
+
+## 개요
+Codeforces(러시아어: Кодфорсес)는 경쟁 프로그래밍(competitive programming) 대회를 개최하는 웹사이트입니다. 미하일 미르자야노프(Mikhail Mirzayanov)가 이끄는 ITMO 대학교의 경쟁 프로그래머 그룹에 의해 유지 및 관리되고 있습니다.
+
+## 사용자와 영향력
+2013년부터 활성 참가자 수 기준으로 TopCoder를 능가했다고 주장하고 있으며, 2019년 기준 60만 명 이상의 등록 사용자를 보유하고 있었습니다. 창립 15주년에는 최소 1회 이상 코드를 제출한 총 사용자 수가 약 170만 명에 달했습니다.
+
+## 주요 참가자
+Codeforces와 유사한 웹사이트들은 Gennady Korotkevich, Petr Mitrichev, Benjamin Qi, Makoto Soejima 등 저명한 스포츠 프로그래머들을 비롯해, 경력 발전에 관심이 있는 수많은 프로그래머들이 자신의 실력을 향상시키고 겨루는 주요 무대로 활용하고 있습니다.

--- a/src/content/organizations/scale-ai.md
+++ b/src/content/organizations/scale-ai.md
@@ -3,10 +3,19 @@ orgId: scale-ai
 name: Scale AI
 type: private
 status: draft
-updated: 2026-05-14
+updated: 2026-05-25
 sources:
   - https://labs.scale.com/
+  - https://en.wikipedia.org/wiki/Scale_AI
 ---
 
 # Scale AI
-<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>
+
+## 개요
+Scale AI는 미국 캘리포니아주 샌프란시스코에 본사를 둔 인공지능 인프라 및 소프트웨어 기업입니다. 초기에는 데이터 주석(Data Annotation) 작업에 중점을 두었으나, 현재는 RLHF(인간 피드백 기반 강화 학습) 서비스, 대규모 언어 모델(LLM) 평가, 그리고 AI 애플리케이션 구축 및 배포를 위한 기업용 소프트웨어 제품군을 함께 제공하고 있습니다.
+
+## 주요 조직 및 서비스
+이 회사의 연구 부문인 'Safety, Evaluation and Alignment Lab'은 LLM의 평가와 정렬(Alignment)에 중점을 두고 있으며, 벤치마크인 'Humanity's Last Exam'을 공동 제작하기도 했습니다. Scale AI는 자회사들을 통해 데이터 라벨링을 아웃소싱하고 있는데, 'Remotasks'는 컴퓨터 비전과 자율주행 차량에 특화되어 있고, 'Outlier'는 LLM을 위한 데이터 주석 작업을 담당합니다.
+
+## 보안 및 협력
+Scale AI는 AI 모델의 취약점, 편향성, 안전 리스크를 식별하기 위해 인간 적대적 테스트를 수행하는 'LLM Red Team'을 운영하고 있습니다. 이 팀은 OpenAI, Google DeepMind, 그리고 국가 AI 안전 기관들과 협력하여 사이버 보안 취약점, 탈옥(Jailbreaks), 에이전트 AI 행동 등 복잡한 위협 요소를 평가합니다. 상업 부문 주요 고객으로는 Google, Microsoft, Meta, General Motors 등이 있으며, 미국 정부의 국방 관련 프로젝트 및 카타르 정부의 사회 프로그램과도 직접 협력하고 있습니다.

--- a/src/data/journal/2026-05-24-profile-benchmark.md
+++ b/src/data/journal/2026-05-24-profile-benchmark.md
@@ -1,0 +1,11 @@
+---
+date: 2026-05-24
+agent: profile-benchmark
+status: completed
+summary: "Scale AI 및 Codeforces 기관 상세 페이지 작성"
+---
+
+## 수행한 작업
+- [x] `scale-ai` 상세 페이지 작성 및 draft 업데이트 ← https://en.wikipedia.org/wiki/Scale_AI
+- [x] `codeforces` 상세 페이지 작성 및 draft 업데이트 ← https://en.wikipedia.org/wiki/Codeforces
+- [x] `mcp-atlas` 상세 페이지 published 승격 (조건 충족)


### PR DESCRIPTION
Updated Scale AI and Codeforces organization profiles with content from Wikipedia. Promoted MCP Atlas to published. Logged the task in the daily journal.

---
*PR created automatically by Jules for task [5897856418592644955](https://jules.google.com/task/5897856418592644955) started by @GGJJack*