### PR TITLE
chore: collect-benchmark daily run (2026-05-25)

### DIFF
--- a/src/data/issues/2026-05-26-collect-benchmark-magistral-medium-1-2.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-magistral-medium-1-2.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/magistral-medium-1-2
+---
+
+## 상황  magistral-medium-1-2 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-ministral-14b-3-0.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-ministral-14b-3-0.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/ministral-14b-3.0
+---
+
+## 상황  ministral-14b-3.0 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-ministral-3b-3-0.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-ministral-3b-3-0.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/ministral-3b-3.0
+---
+
+## 상황  ministral-3b-3.0 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그(https://mistral.ai/news/) 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-ministral-8b-3-0.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-ministral-8b-3-0.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/ministral-8b-3.0
+---
+
+## 상황  ministral-8b-3.0 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-nvidia-nemotron-nano-2-vl.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-nvidia-nemotron-nano-2-vl.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/nvidia-nemotron-nano-2-vl
+---
+
+## 상황  nvidia-nemotron-nano-2-vl 벤치마크 점수 출처 부재
+## 시도한 것  HuggingFace(https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16) 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-palmyra-vision-7b.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-palmyra-vision-7b.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/palmyra-vision-7b
+---
+
+## 상황  palmyra-vision-7b 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-palmyra-x4.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-palmyra-x4.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/palmyra-x4
+---
+
+## 상황  palmyra-x4 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-palmyra-x5.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-palmyra-x5.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/palmyra-x5
+---
+
+## 상황  palmyra-x5 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그(https://writer.com/blog/) 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/issues/2026-05-26-collect-benchmark-qwen-3-32b.md
+++ b/src/data/issues/2026-05-26-collect-benchmark-qwen-3-32b.md
@@ -1,0 +1,10 @@
+---
+created: 2026-05-26
+agent: collect-benchmark
+severity: minor
+target: llm/qwen-3-32b
+---
+
+## 상황  qwen-3-32b 벤치마크 점수 출처 부재
+## 시도한 것  공식 블로그(https://qwenlm.github.io/blog/) 등 검색
+## 요청  점수 출처 확인 및 등록

--- a/src/data/journal/2026-05-25-collect-benchmark.md
+++ b/src/data/journal/2026-05-25-collect-benchmark.md
@@ -1,0 +1,34 @@
+---
+date: 2026-05-25
+agent: collect-benchmark
+status: completed
+summary: "신규 LLM 모델들에 대한 벤치마크 점수 탐색 결과 출처 부재로 이슈 티켓 9건 생성"
+---
+
+## Todo
+- [x] 신규 LLM 모델 점수 매칭 시도 (qwen-3-32b, nvidia-nemotron-nano-2-vl, palmyra, ministral)
+
+## 조사 내역
+- 01:30 qwen-3-32b 벤치마크 탐색 ← https://qwenlm.github.io/blog/
+- 01:35 nvidia-nemotron-nano-2-vl 탐색 ← https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+- 01:40 palmyra 시리즈 및 ministral/magistral 시리즈 벤치마크 탐색 ← https://writer.com/blog/, https://mistral.ai/news/
+
+## 수행한 작업
+- [x] qwen-3-32b 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-26-collect-benchmark-qwen-3-32b.md
+- [x] nvidia-nemotron-nano-2-vl 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-26-collect-benchmark-nvidia-nemotron-nano-2-vl.md
+- [x] palmyra-x5, palmyra-x4, palmyra-vision-7b 모델 이슈 티켓 생성 ← issues/2026-05-26-collect-benchmark-palmyra-x5.md 등
+- [x] ministral-3b-3.0, ministral-8b-3.0, ministral-14b-3.0, magistral-medium-1-2 모델 이슈 티켓 생성 ← issues/2026-05-26-collect-benchmark-ministral-3b-3-0.md 등
+
+## 판단 / 고민
+- 등록된 신규 모델들의 벤치마크 점수를 공식 출처에서 명확히 찾기 어려워 이슈 티켓으로 이관함.
+
+## 이슈 제기
+- issues/2026-05-26-collect-benchmark-qwen-3-32b.md
+- issues/2026-05-26-collect-benchmark-nvidia-nemotron-nano-2-vl.md
+- issues/2026-05-26-collect-benchmark-palmyra-x5.md
+- issues/2026-05-26-collect-benchmark-palmyra-x4.md
+- issues/2026-05-26-collect-benchmark-palmyra-vision-7b.md
+- issues/2026-05-26-collect-benchmark-ministral-3b-3-0.md
+- issues/2026-05-26-collect-benchmark-ministral-8b-3-0.md
+- issues/2026-05-26-collect-benchmark-ministral-14b-3-0.md
+- issues/2026-05-26-collect-benchmark-magistral-medium-1-2.md


### PR DESCRIPTION
- Checked official sources for `qwen-3-32b`, `nvidia-nemotron-nano-2-vl`, `palmyra` and `ministral` series models registered on 2026-05-24.
- Couldn't find verifiable specific benchmark scores on official sources for them.
- Created 9 issue tickets marking the missing benchmark sources in `src/data/issues/`.
- Documented findings and actions in `src/data/journal/2026-05-25-collect-benchmark.md`.

---
*PR created automatically by Jules for task [16126820943597522383](https://jules.google.com/task/16126820943597522383) started by @GGJJack*