### PR TITLE
docs: publish daily report for 2026-05-25

### DIFF
--- a/src/data/journal/2026-05-26-journal.md
+++ b/src/data/journal/2026-05-26-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-26
+agent: journal
+status: completed
+summary: "2026-05-25 데일리 리포트 발행"
+---
+
+## 수행한 작업
+- [x] 2026-05-25 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark 저널을 취합하여 데일리 리포트 작성 및 `src/data/updates/2026-05-25-daily.md` 로 발행 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-25-daily.md
+++ b/src/data/updates/2026-05-25-daily.md
@@ -1,0 +1,49 @@
+---
+date: 2026-05-25
+type: note
+title: 데일리 리포트 · 2026-05-25
+summary: "신규 모델 등록(leanstral 등) 및 벤치마크 탐색 완료. 출처 불명으로 10건의 이슈 티켓 생성"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- [x] 신규 모델 등록: `leanstral` (Mistral AI) ← https://docs.mistral.ai/models/model-cards/leanstral-26-03
+- [x] 신규 모델 등록: `hcx-007`, `hcx-dash-002` (NAVER Cloud) ← https://www.ncloud.com/product/ai/clovaStudio
+- [x] 기존 모델 보강: `mistral-medium-3-5` 가격 및 출처 업데이트 ($1.5/$7.5) ← https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04
+- [x] 기존 모델 보강: `deepseek-v4-pro`, `deepseek-v4-flash` 가격 및 컨텍스트 윈도우 업데이트 ← https://api-docs.deepseek.com/quick_start/pricing
+- [x] 기존 모델 보강: `voxtral-mini-1-0`, `voxtral-small-1-0` 가격 및 상세 정보 업데이트 ← Amazon Bedrock
+- [x] 기존 모델 보강: `mistral-small-4` 라이선스 및 파라미터 정보 업데이트 ← https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03
+- [x] 시스템 정합성 확인: `bun run build` 통과 확인
+
+### 벤치마크 (collect-benchmark)
+- [x] qwen-3-32b 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-26-collect-benchmark-qwen-3-32b.md
+- [x] nvidia-nemotron-nano-2-vl 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-26-collect-benchmark-nvidia-nemotron-nano-2-vl.md
+- [x] palmyra-x5, palmyra-x4, palmyra-vision-7b 모델 이슈 티켓 생성 ← issues/2026-05-26-collect-benchmark-palmyra-x5.md 등
+- [x] ministral-3b-3.0, ministral-8b-3.0, ministral-14b-3.0, magistral-medium-1-2 모델 이슈 티켓 생성 ← issues/2026-05-26-collect-benchmark-ministral-3b-3-0.md 등
+
+## 상세 페이지 작성 (profile)
+- 10:20 저널 생성 및 대상 선정 (leanstral, hcx-007)
+- 10:40 Leanstral 프로파일 작성 완료 (`src/content/models/leanstral.md`)
+- 11:00 HCX-007 프로파일 작성 완료 (`src/content/models/hcx-007.md`)
+- 11:10 `bun run build`를 통한 스키마 및 빌드 검증 완료
+- [x] `src/content/benchmarks/livecodebench-v6.md` 생성 (draft) ← https://arxiv.org/abs/2403.07974, https://livecodebench.github.io/
+- [x] `src/content/benchmarks/hle.md` 생성 (draft) ← https://arxiv.org/abs/2501.14249, https://lastexam.ai/
+- [x] `src/content/organizations/cais.md` 스텁 생성 (draft) ← https://arxiv.org/abs/2501.14249
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 10건
+
+## 미해결 이슈
+
+- issues/2026-05-26-collect-benchmark-qwen-3-32b.md
+- issues/2026-05-26-collect-benchmark-nvidia-nemotron-nano-2-vl.md
+- issues/2026-05-26-collect-benchmark-palmyra-x5.md
+- issues/2026-05-26-collect-benchmark-palmyra-x4.md
+- issues/2026-05-26-collect-benchmark-palmyra-vision-7b.md
+- issues/2026-05-26-collect-benchmark-ministral-3b-3-0.md
+- issues/2026-05-26-collect-benchmark-ministral-8b-3-0.md
+- issues/2026-05-26-collect-benchmark-ministral-14b-3-0.md
+- issues/2026-05-26-collect-benchmark-magistral-medium-1-2.md
+
+- issues/2026-05-25-profile-benchmark-cais.md 생성 (기관 상세 조사 필요)


### PR DESCRIPTION
This PR publishes the daily update report for 2026-05-25 by aggregating activities from `collect-llm`, `collect-benchmark`, `profile-model`, and `profile-benchmark` journal logs.

It also creates the completion journal for the `journal` agent for today (2026-05-26), accurately summarizing the task and marking `status: completed`.

---
*PR created automatically by Jules for task [11125094255314891623](https://jules.google.com/task/11125094255314891623) started by @GGJJack*