### PR TITLE
chore(benchmark): collect missing LLM benchmark scores and raise issues

### DIFF
--- a/src/data/issues/2026-05-27-collect-benchmark-hcx-007.md
+++ b/src/data/issues/2026-05-27-collect-benchmark-hcx-007.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: collect-benchmark
+severity: minor
+target: llm/hcx-007
+---
+
+## 상황
+해당 모델의 벤치마크 점수를 찾을 수 없습니다.
+
+## 시도한 것
+NAVER Cloud 공식 문서를 확인했으나 벤치마크 점수가 기재되어 있지 않았습니다.
+
+## 요청
+해당 모델의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/issues/2026-05-27-collect-benchmark-hcx-dash-002.md
+++ b/src/data/issues/2026-05-27-collect-benchmark-hcx-dash-002.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: collect-benchmark
+severity: minor
+target: llm/hcx-dash-002
+---
+
+## 상황
+해당 모델의 벤치마크 점수를 찾을 수 없습니다.
+
+## 시도한 것
+NAVER Cloud 공식 문서를 확인했으나 벤치마크 점수가 기재되어 있지 않았습니다.
+
+## 요청
+해당 모델의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/issues/2026-05-27-collect-benchmark-leanstral.md
+++ b/src/data/issues/2026-05-27-collect-benchmark-leanstral.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: collect-benchmark
+severity: minor
+target: llm/leanstral
+---
+
+## 상황
+해당 모델의 벤치마크 점수를 찾을 수 없습니다.
+
+## 시도한 것
+공식 문서(https://docs.mistral.ai/models/model-cards/leanstral-26-03)를 확인했으나 벤치마크 점수가 기재되어 있지 않았습니다.
+
+## 요청
+해당 모델의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/issues/2026-05-27-collect-benchmark-mistral-small-4.md
+++ b/src/data/issues/2026-05-27-collect-benchmark-mistral-small-4.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: collect-benchmark
+severity: minor
+target: llm/mistral-small-4
+---
+
+## 상황
+해당 모델의 벤치마크 점수를 찾을 수 없습니다.
+
+## 시도한 것
+Mistral AI 공식 문서를 확인했으나 명확한 벤치마크 점수를 추출하기 어려웠습니다.
+
+## 요청
+해당 모델의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/issues/2026-05-27-collect-benchmark-voxtral-mini-1-0.md
+++ b/src/data/issues/2026-05-27-collect-benchmark-voxtral-mini-1-0.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: collect-benchmark
+severity: minor
+target: llm/voxtral-mini-1-0
+---
+
+## 상황
+해당 모델의 벤치마크 점수를 찾을 수 없습니다.
+
+## 시도한 것
+공식 페이지를 확인했으나 벤치마크 점수가 기재되어 있지 않았습니다.
+
+## 요청
+해당 모델의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/issues/2026-05-27-collect-benchmark-voxtral-small-1-0.md
+++ b/src/data/issues/2026-05-27-collect-benchmark-voxtral-small-1-0.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: collect-benchmark
+severity: minor
+target: llm/voxtral-small-1-0
+---
+
+## 상황
+해당 모델의 벤치마크 점수를 찾을 수 없습니다.
+
+## 시도한 것
+공식 페이지를 확인했으나 벤치마크 점수가 기재되어 있지 않았습니다.
+
+## 요청
+해당 모델의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/journal/2026-05-26-collect-benchmark.md
+++ b/src/data/journal/2026-05-26-collect-benchmark.md
@@ -1,0 +1,33 @@
+---
+date: 2026-05-26
+agent: collect-benchmark
+status: completed
+summary: "신규 LLM 모델 벤치마크 점수 매칭 및 이슈 생성"
+---
+
+## Todo
+- [ ] 신규 모델(leanstral, hcx-007, hcx-dash-002 등) 벤치마크 점수 매칭
+- [ ] 점수 확인 불가 시 이슈 티켓 생성
+
+## 조사 내역
+- 01:30 Mistral AI (Leanstral, Mistral Small 4), NAVER Cloud (HCX), Amazon Bedrock (Voxtral) 공식 문서에서 벤치마크 점수 탐색 시도
+- 공식 벤치마크 출처 부재로 이슈 티켓 생성
+
+## 수행한 작업
+- [x] leanstral 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-27-collect-benchmark-leanstral.md
+- [x] hcx-007 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-27-collect-benchmark-hcx-007.md
+- [x] hcx-dash-002 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-27-collect-benchmark-hcx-dash-002.md
+- [x] voxtral-mini-1-0 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-27-collect-benchmark-voxtral-mini-1-0.md
+- [x] voxtral-small-1-0 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-27-collect-benchmark-voxtral-small-1-0.md
+- [x] mistral-small-4 모델 이슈 티켓 생성 (공식 벤치마크 출처 부재) ← issues/2026-05-27-collect-benchmark-mistral-small-4.md
+
+## 판단 / 고민
+- 등록된 신규 모델들의 벤치마크 점수를 공식 출처에서 찾을 수 없어 이슈 티켓으로 이관함.
+
+## 이슈 제기
+- issues/2026-05-27-collect-benchmark-leanstral.md
+- issues/2026-05-27-collect-benchmark-hcx-007.md
+- issues/2026-05-27-collect-benchmark-hcx-dash-002.md
+- issues/2026-05-27-collect-benchmark-voxtral-mini-1-0.md
+- issues/2026-05-27-collect-benchmark-voxtral-small-1-0.md
+- issues/2026-05-27-collect-benchmark-mistral-small-4.md


### PR DESCRIPTION
- Attempts to collect benchmarks for recent LLM models (leanstral, mistral-small-4, hcx-007, hcx-dash-002, voxtral-mini-1-0, voxtral-small-1-0)
- Official sources and leaderboards lacked clear benchmark scores for these models.
- Issue tickets were generated in \`src/data/issues/\` to defer score matching instead of hallucinating data.
- The `collect-benchmark` UTC journal was recorded for the session.

---
*PR created automatically by Jules for task [462238757728081856](https://jules.google.com/task/462238757728081856) started by @GGJJack*