### PR TITLE
feat(profile-benchmark): add cweval and scicode benchmarks, create scicode-bench stub

### DIFF
--- a/src/content/benchmarks/cweval.md
+++ b/src/content/benchmarks/cweval.md
@@ -1,0 +1,22 @@
+---
+benchmarkId: cweval
+domain: llm
+status: draft
+updated: 2026-05-26
+sources:
+  - https://github.com/Co1lin/CWEval
+highlights:
+  - "보안성과 기능성을 동시에 평가하는 벤치마크"
+  - "결과 중심적 테스트 기반의 평가 프레임워크"
+---
+
+# CWEval
+
+## 개요
+CWEval은 대형 언어 모델(LLM)이 생성한 코드의 기능성(Functionality)과 보안성(Security)을 동시에 평가하기 위해 고안된 벤치마크 프레임워크입니다.
+
+## 평가 방법
+결과 중심적(outcome-driven) 평가 프레임워크를 도입하여, 생성된 코드가 단순히 정상 작동하는지를 넘어 보안 취약점이 없는지 함께 테스트합니다.
+
+## 한계와 비판
+TBD.

--- a/src/content/benchmarks/scicode.md
+++ b/src/content/benchmarks/scicode.md
@@ -1,0 +1,25 @@
+---
+benchmarkId: scicode
+domain: llm
+status: draft
+updated: 2026-05-26
+sources:
+  - https://arxiv.org/abs/2407.13168
+  - https://github.com/scicode-bench/SciCode
+organization: scicode-bench
+paperUrl: https://arxiv.org/abs/2407.13168
+highlights:
+  - "과학 연구 문제 해결 능력을 평가하는 코딩 벤치마크"
+  - "수학, 물리학, 화학 등 16개 분야 과학자들이 직접 큐레이션"
+---
+
+# SciCode
+
+## 개요
+SciCode는 수학, 물리학, 화학, 생물학, 재료 과학 등 16개 자연 과학 분야의 과학자들과 AI 연구자들이 참여하여 만든 고품질 코딩 벤치마크입니다. 언어 모델이 실제 과학 연구 문제를 해결하기 위한 코드를 생성할 수 있는지를 평가합니다.
+
+## 문제 구성
+총 80개의 주요 도전 문제에서 분해된 338개의 하위 문제로 구성되며, 각 문제는 지식 회상, 추론 및 코드 합성을 요구합니다.
+
+## 평가 방법
+모델이 생성한 코드에 대해 과학자들이 주석 처리한 정답 코드 및 테스트 케이스를 기반으로 평가가 이루어집니다.

--- a/src/content/organizations/scicode-bench.md
+++ b/src/content/organizations/scicode-bench.md
@@ -1,0 +1,12 @@
+---
+orgId: scicode-bench
+name: SciCode Bench
+status: draft
+updated: 2026-05-26
+sources:
+  - https://github.com/scicode-bench
+---
+
+# SciCode Bench
+
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-05-27-profile-benchmark-scicode-bench-org.md
+++ b/src/data/issues/2026-05-27-profile-benchmark-scicode-bench-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-27
+agent: profile-benchmark
+severity: minor
+target: organization/scicode-bench
+---
+
+## 상황
+SciCode 벤치마크의 조직인 `scicode-bench`에 대한 상세 정보가 부족하여 스텁만 생성된 상태입니다. 출처가 GitHub 프로필(`https://github.com/scicode-bench`)에만 한정되어 있습니다.
+
+## 시도한 것
+`profile-benchmark` 실행 중 `scicode` 벤치마크 등록 시 연관 기관으로 추가함.
+
+## 요청
+해당 기관의 설립, 소속(affiliations), 공식 웹사이트 등의 추가 조사를 통해 `src/content/organizations/scicode-bench.md` 보강 필요.

--- a/src/data/journal/2026-05-26-profile-benchmark.md
+++ b/src/data/journal/2026-05-26-profile-benchmark.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-26
+agent: profile-benchmark
+status: completed
+summary: "CWEval, SciCode 벤치마크 상세 페이지 작성 완료 및 SciCode Bench 기관 스텁 생성"
+---
+
+## Todo
+- `src/content/benchmarks/cweval.md` 작성
+- `src/content/benchmarks/scicode.md` 작성
+- `src/content/organizations/scicode-bench.md` 스텁 작성 및 이슈 티켓 발급
+
+## 조사 내역
+- 02:30 CWEval (보안 및 기능성 동시 평가 프레임워크) 조사 ← https://github.com/Co1lin/CWEval
+- 02:30 SciCode (자연과학 문제 코딩 벤치마크) 조사 ← https://arxiv.org/abs/2407.13168
+- 02:30 scicode-bench 기관 조사 ← https://github.com/scicode-bench
+
+## 수행한 작업
+- [x] `src/content/benchmarks/cweval.md` 생성 (상태: draft) ← https://github.com/Co1lin/CWEval
+- [x] `src/content/benchmarks/scicode.md` 생성 (상태: draft) ← https://arxiv.org/abs/2407.13168, https://github.com/scicode-bench/SciCode
+- [x] `src/content/organizations/scicode-bench.md` 스텁 생성 (상태: draft) ← https://github.com/scicode-bench
+- [x] `src/data/issues/2026-05-27-profile-benchmark-scicode-bench-org.md` 티켓 발급
+
+## 판단 / 고민
+- CWEval 논문의 arXiv ID를 찾지 못하여 공식 GitHub 저장소만을 출처로 사용함.
+- SciCode 벤치마크의 주요 주체는 여러 학문 분야 과학자 및 AI 연구자들의 협력으로 구성되었으나, 명확한 단일 기관이 없어 GitHub 조직(`scicode-bench`)을 기관으로 등록하고 스텁 생성 후 이슈 발급.
+
+## 이슈 제기
+- issues/2026-05-27-profile-benchmark-scicode-bench-org.md


### PR DESCRIPTION
Adds benchmark profiles for CWEval and SciCode, creates an organization stub for scicode-bench, files an issue ticket for further organization research, and logs the execution in the profile-benchmark journal.

---
*PR created automatically by Jules for task [11822050591168845730](https://jules.google.com/task/11822050591168845730) started by @GGJJack*