### PR TITLE
Publish daily report for 2026-05-26

### DIFF
--- a/src/data/journal/2026-05-27-journal.md
+++ b/src/data/journal/2026-05-27-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-27
+agent: journal
+status: completed
+summary: "2026-05-26 데일리 리포트 발행"
+---
+
+## 수행한 작업
+- [x] 2026-05-26 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark 저널을 취합하여 데일리 리포트 작성 및 `src/data/updates/2026-05-26-daily.md` 로 발행 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-26-daily.md
+++ b/src/data/updates/2026-05-26-daily.md
@@ -1,0 +1,38 @@
+---
+date: 2026-05-26
+type: note
+title: "데일리 리포트 · 2026-05-26"
+summary: "신규 LLM 3건 수집 및 상세 페이지 5건 발행, 벤치마크 미해결 이슈 7건"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: Grok Build 0.1 (xAI) (https://x.ai/news/grok-build-cli)
+- 신규: Qwen3-Coder-480B-A35B-Instruct (Alibaba Cloud) (https://qwenlm.github.io/blog/qwen3-coder/)
+- 신규: HCX-005 (NAVER Cloud) (https://www.ncloud.com/product/ai/clovaStudio)
+- 보강: Qwen3Guard (Alibaba Cloud) · parameterSize, links.huggingface
+- 보강: Gemini 3.5 Flash (Google) · links.paper
+- 보강: HCX-007 (NAVER Cloud) · contextWindow
+
+### 벤치마크 (collect-benchmark)
+- 신규 모델 벤치마크 점수 매칭 시도했으나 공식 출처 부재로 이슈 6건 발생
+
+## 상세 페이지 작성 (profile)
+- models/grok-build-0.1 · status=published
+- models/qwen3-coder-480b-instruct · status=published
+- benchmarks/cweval · status=draft
+- benchmarks/scicode · status=draft
+- organizations/scicode-bench · status=draft
+
+## 이슈 처리 (reinforce)
+- (처리 내역 없음)
+
+## 미해결 이슈
+- issues/2026-05-27-collect-benchmark-leanstral.md — 공식 벤치마크 출처 부재
+- issues/2026-05-27-collect-benchmark-hcx-007.md — 공식 벤치마크 출처 부재
+- issues/2026-05-27-collect-benchmark-hcx-dash-002.md — 공식 벤치마크 출처 부재
+- issues/2026-05-27-collect-benchmark-voxtral-mini-1-0.md — 공식 벤치마크 출처 부재
+- issues/2026-05-27-collect-benchmark-voxtral-small-1-0.md — 공식 벤치마크 출처 부재
+- issues/2026-05-27-collect-benchmark-mistral-small-4.md — 공식 벤치마크 출처 부재
+- issues/2026-05-27-profile-benchmark-scicode-bench-org.md — 단일 기관 부재로 인한 스텁 생성


### PR DESCRIPTION
Published the daily report for 2026-05-26 summarizing activities from the agent journals, and updated the journal agent's own task journal.

---
*PR created automatically by Jules for task [1998218189598772770](https://jules.google.com/task/1998218189598772770) started by @GGJJack*