### PR TITLE
chore: collect-benchmark daily task execution and generate issue tickets for missing scores

### DIFF
--- a/src/data/issues/2026-05-28-collect-benchmark-grok-build-0.1.md
+++ b/src/data/issues/2026-05-28-collect-benchmark-grok-build-0.1.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-28
+agent: collect-benchmark
+severity: minor
+target: llm/grok-build-0.1
+---
+
+## 상황
+공식 출처(https://x.ai/news/grok-build-cli, https://docs.x.ai/developers/models/grok-build-0.1)에 벤치마크 점수가 텍스트 형태로 명시되어 있지 않음.
+
+## 시도한 것
+공식 블로그 및 개발자 문서 탐색.
+
+## 요청
+해당 모델의 공식 벤치마크 점수 탐색 및 등록 (있는 경우).

--- a/src/data/issues/2026-05-28-collect-benchmark-hcx-005.md
+++ b/src/data/issues/2026-05-28-collect-benchmark-hcx-005.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-28
+agent: collect-benchmark
+severity: minor
+target: llm/hcx-005
+---
+
+## 상황
+공식 출처(https://www.ncloud.com/product/ai/clovaStudio)에 벤치마크 점수가 공개되어 있지 않음.
+
+## 시도한 것
+공식 소개 페이지 내용 확인.
+
+## 요청
+해당 모델의 공식 벤치마크 점수 탐색 및 등록.

--- a/src/data/issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md
+++ b/src/data/issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-28
+agent: collect-benchmark
+severity: minor
+target: llm/qwen3-coder-480b-instruct
+---
+
+## 상황
+공식 출처(https://qwenlm.github.io/blog/qwen3-coder/)에 SWE-bench 등 구체적인 점수가 텍스트로 누락되었거나 찾을 수 없음.
+
+## 시도한 것
+공식 블로그 게시글 내용 스크래핑 및 검색.
+
+## 요청
+해당 모델의 공식 벤치마크 점수 탐색 및 등록.

--- a/src/data/journal/2026-05-28-collect-benchmark.md
+++ b/src/data/journal/2026-05-28-collect-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-05-28
+agent: collect-benchmark
+status: completed
+summary: "신규 LLM 모델 (Grok Build 0.1, Qwen3-Coder-480B-A35B-Instruct, HCX-005) 벤치마크 점수 매칭 시도 및 이슈 생성"
+---
+
+## Todo
+- [x] 신규 등록된 LLM 모델의 벤치마크 점수 검색
+- [x] 점수 미발견 시 이슈 티켓 생성
+
+## 조사 내역
+- 01:30 Grok Build 0.1 공식 문서 및 뉴스 탐색 (https://x.ai/news/grok-build-cli) - 벤치마크 점수 없음.
+- 01:35 Qwen3-Coder-480B-A35B-Instruct 공식 블로그 탐색 (https://qwenlm.github.io/blog/qwen3-coder/) - 텍스트 기반 벤치마크 수치 없음.
+- 01:40 HCX-005 클로바 스튜디오 공식 페이지 탐색 (https://www.ncloud.com/product/ai/clovaStudio) - 벤치마크 수치 없음.
+
+## 수행한 작업
+- [x] grok-build-0.1 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-28-collect-benchmark-grok-build-0.1.md
+- [x] qwen3-coder-480b-instruct 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md
+- [x] hcx-005 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-28-collect-benchmark-hcx-005.md
+
+## 판단 / 고민
+- 세 가지 모델 모두 공식 안내 페이지에 구체적 수치가 텍스트로 제시되어 있지 않아 점수 등록을 스킵하고 이슈 티켓으로 넘김.
+
+## 이슈 제기
+- issues/2026-05-28-collect-benchmark-grok-build-0.1.md
+- issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md
+- issues/2026-05-28-collect-benchmark-hcx-005.md


### PR DESCRIPTION
Executed the `collect-benchmark` task for the newly registered LLM models (Grok Build 0.1, Qwen3-Coder-480B-A35B-Instruct, HCX-005). As no textual benchmark scores were found on their official documentation, generated the required issue tickets in `src/data/issues/` according to the constraints. Also created the daily journal detailing the actions taken.

---
*PR created automatically by Jules for task [6112685132495604023](https://jules.google.com/task/6112685132495604023) started by @GGJJack*