### PR TITLE
feat(profile-benchmark): add benchmark profiles and track progress

### DIFF
--- a/src/content/benchmarks/swe-bench-multilingual.md
+++ b/src/content/benchmarks/swe-bench-multilingual.md
@@ -1,0 +1,16 @@
+---
+benchmarkId: swe-bench-multilingual
+domain: llm
+status: draft
+updated: 2026-05-27
+sources:
+  - https://www.swebench.com/
+---
+
+# SWE-bench Multilingual
+
+## 개요
+Multilingual software engineering benchmark.
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/content/benchmarks/tau-bench.md
+++ b/src/content/benchmarks/tau-bench.md
@@ -1,0 +1,16 @@
+---
+benchmarkId: tau-bench
+domain: llm
+status: draft
+updated: 2026-05-27
+sources:
+  - https://github.com/sierra-research/tau-bench
+---
+
+# tau-Bench
+
+## 개요
+Interactive tool invocation benchmark.
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/data/issues/2026-05-28-profile-benchmark-tau-bench-org.md
+++ b/src/data/issues/2026-05-28-profile-benchmark-tau-bench-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-28
+agent: profile-benchmark
+severity: minor
+target: organization/tau-bench-org
+---
+
+## 상황
+`tau-bench` 벤치마크 등록 과정에서 기관 정보가 부족하여 기관 페이지를 생성하지 못했습니다. 상세 조사가 필요합니다.
+
+## 시도한 것
+벤치마크 상세 페이지(`src/content/benchmarks/tau-bench.md`)를 작성했으나, 확실한 기관 ID를 특정할 수 없었습니다.
+
+## 요청
+`tau-bench`를 제작한 기관에 대한 상세 정보(설립일, 본사, 공식 웹사이트 등)를 조사하여 알맞은 기관 ID로 기관 페이지를 생성해 주세요.

--- a/src/data/journal/2026-05-27-profile-benchmark.md
+++ b/src/data/journal/2026-05-27-profile-benchmark.md
@@ -1,0 +1,18 @@
+---
+date: 2026-05-27
+agent: profile-benchmark
+status: completed
+summary: "swe-bench-multilingual, tau-bench 상세 페이지 작성 및 기관 누락 이슈 생성"
+---
+
+## Todo
+## 조사 내역
+- 02:30 swe-bench-multilingual 공식 페이지 확인 ← https://www.swebench.com/
+- 02:35 tau-bench GitHub 저장소 확인 ← https://github.com/sierra-research/tau-bench
+
+## 수행한 작업
+- [x] `swe-bench-multilingual` 상세 페이지 작성 ← https://www.swebench.com/
+- [x] `tau-bench` 상세 페이지 작성 ← https://github.com/sierra-research/tau-bench
+## 판단 / 고민
+## 이슈 제기
+- issues/2026-05-28-profile-benchmark-tau-bench-org.md


### PR DESCRIPTION
This PR implements the automated `profile-benchmark` task for `2026-05-27`. It introduces two new benchmark profile pages for `swe-bench-multilingual` and `tau-bench` based on their respective JSON configurations and verified external sources. It also logs an issue to the system to request a backfill on the missing organization metadata for `tau-bench-org` to handle missing entities properly, and tracks the execution inside the daily journal.

---
*PR created automatically by Jules for task [1381965150402651224](https://jules.google.com/task/1381965150402651224) started by @GGJJack*