### PR TITLE
feat(journal): generate 2026-05-27 daily report

### DIFF
--- a/src/data/journal/2026-05-28-journal.md
+++ b/src/data/journal/2026-05-28-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-28
+agent: journal
+status: completed
+summary: "2026-05-27 데일리 리포트 발행"
+---
+
+## 수행한 작업
+- [x] 2026-05-27 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark, reinforce 저널을 취합하여 데일리 리포트 작성 및 \`src/data/updates/2026-05-27-daily.md\` 로 발행 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-27-daily.md
+++ b/src/data/updates/2026-05-27-daily.md
@@ -1,0 +1,34 @@
+---
+date: 2026-05-27
+type: note
+title: 데일리 리포트 · 2026-05-27
+summary: "swe-bench-multilingual, tau-bench 상세 페이지 작성 및 기관 누락 이슈 생성 / GPT-OSS-120B 및 HCX-DASH-002 모델 상세 페이지 작성 완료"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: GPT-OSS-120B (OpenAI)
+- 신규: GPT-OSS-20B (OpenAI)
+- 보강: Granite 4.1 8B (IBM)
+- 보강: Granite 4.1 3B (IBM)
+- 보강: HCX-005 (NAVER Cloud)
+- 보강: HCX-DASH-002 (NAVER Cloud)
+
+### 벤치마크 (collect-benchmark)
+- 내용 없음
+
+## 상세 페이지 작성 (profile)
+- `swe-bench-multilingual` 상세 페이지 작성 ← https://www.swebench.com/
+- `tau-bench` 상세 페이지 작성 ← https://github.com/sierra-research/tau-bench
+- `src/content/models/gpt-oss-120b.md` 생성
+- `src/content/models/hcx-dash-002.md` 생성
+- `bun run build`를 통한 Zod 스키마 검증 완료
+
+## 이슈 처리 (reinforce)
+- 내용 없음
+
+## 미해결 이슈
+- `pricing` for **Command A+ (05-2026)**, **Granite 4.1 family**, **Qwen3-Coder-480B**, **HCX-007/005/DASH-002**.
+- `parameterSize` for **HCX family**.
+- issues/2026-05-28-profile-benchmark-tau-bench-org.md


### PR DESCRIPTION
- Parses `2026-05-27` journals (`collect-*`, `profile-*`, `reinforce`)
- Aggregates the contents and writes the daily report to `src/data/updates/2026-05-27-daily.md`
- Creates today's journal file (`src/data/journal/2026-05-28-journal.md`) and marks it as completed
- Ran `bun run build` successfully to verify frontend components and schema.

---
*PR created automatically by Jules for task [4871101475345193797](https://jules.google.com/task/4871101475345193797) started by @GGJJack*