### PR TITLE
chore: match benchmarks for newly collected LLMs

### DIFF
--- a/src/data/issues/2026-05-29-collect-benchmark-gpt-oss-120b.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-gpt-oss-120b.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: minor
+target: llm/gpt-oss-120b
+---
+
+## 상황
+gpt-oss-120b 모델의 벤치마크 점수를 확인할 수 있는 공식 문서(https://www.ibm.com/products/watsonx-ai/pricing)에 구체적인 수치가 없습니다.
+
+## 시도한 것
+IBM Watsonx 가격 페이지와 관련 문서를 탐색했으나 벤치마크 데이터를 찾지 못했습니다.
+
+## 요청
+해당 모델의 공식 벤치마크 출처가 확보되면 점수를 매칭해주세요.

--- a/src/data/issues/2026-05-29-collect-benchmark-gpt-oss-20b.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-gpt-oss-20b.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: minor
+target: llm/gpt-oss-20b
+---
+
+## 상황
+gpt-oss-20b 모델의 벤치마크 점수를 확인할 수 있는 공식 문서(https://www.ibm.com/products/watsonx-ai/pricing)에 구체적인 수치가 없습니다.
+
+## 시도한 것
+IBM Watsonx 가격 페이지와 관련 문서를 탐색했으나 벤치마크 데이터를 찾지 못했습니다.
+
+## 요청
+해당 모델의 공식 벤치마크 출처가 확보되면 점수를 매칭해주세요.

--- a/src/data/issues/2026-05-29-collect-benchmark-hcx-007.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-hcx-007.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: minor
+target: llm/hcx-007
+---
+
+## 상황
+hcx-007 모델의 벤치마크 점수를 확인할 수 있는 공식 페이지(https://www.ncloud.com/product/ai/clovaStudio)에 구체적인 수치가 제공되지 않습니다.
+
+## 시도한 것
+NAVER Cloud CLOVA Studio 페이지를 탐색했으나 벤치마크 데이터를 찾지 못했습니다.
+
+## 요청
+해당 모델의 공식 벤치마크 출처가 확보되면 점수를 매칭해주세요.

--- a/src/data/issues/2026-05-29-collect-benchmark-hcx-dash-002.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-hcx-dash-002.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: minor
+target: llm/hcx-dash-002
+---
+
+## 상황
+hcx-dash-002 모델의 벤치마크 점수를 확인할 수 있는 공식 페이지(https://www.ncloud.com/product/ai/clovaStudio)에 구체적인 수치가 제공되지 않습니다.
+
+## 시도한 것
+NAVER Cloud CLOVA Studio 페이지를 탐색했으나 벤치마크 데이터를 찾지 못했습니다.
+
+## 요청
+해당 모델의 공식 벤치마크 출처가 확보되면 점수를 매칭해주세요.

--- a/src/data/journal/2026-05-28-collect-benchmark.md
+++ b/src/data/journal/2026-05-28-collect-benchmark.md
@@ -2,7 +2,7 @@
 date: 2026-05-28
 agent: collect-benchmark
 status: completed
-summary: "신규 LLM 모델 (Grok Build 0.1, Qwen3-Coder-480B-A35B-Instruct, HCX-005) 벤치마크 점수 매칭 시도 및 이슈 생성"
+summary: "신규 LLM 모델 (Grok Build 0.1, Qwen3-Coder-480B-A35B-Instruct, HCX-005, GPT-OSS-120B, GPT-OSS-20B, HCX-007, HCX-DASH-002) 벤치마크 점수 매칭 시도 및 이슈 생성"
 ---
 
 ## Todo
@@ -26,3 +26,28 @@ summary: "신규 LLM 모델 (Grok Build 0.1, Qwen3-Coder-480B-A35B-Instruct, HCX
 - issues/2026-05-28-collect-benchmark-grok-build-0.1.md
 - issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md
 - issues/2026-05-28-collect-benchmark-hcx-005.md
+
+## 이어서 (16:52)
+
+## Todo
+- [x] 전날 신규 등록된 LLM 모델(GPT-OSS-120B, GPT-OSS-20B, HCX-007, HCX-DASH-002)의 벤치마크 점수 검색 및 매칭 시도
+- [x] 점수 미발견 시 이슈 티켓 생성
+
+## 조사 내역
+- 16:45 GPT-OSS-120B, GPT-OSS-20B 가격 페이지 확인 (https://www.ibm.com/products/watsonx-ai/pricing) - 벤치마크 점수 없음.
+- 16:50 HCX-007, HCX-DASH-002 공식 안내 페이지 확인 (https://www.ncloud.com/product/ai/clovaStudio) - 벤치마크 수치 없음.
+
+## 수행한 작업
+- [x] gpt-oss-120b 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-gpt-oss-120b.md
+- [x] gpt-oss-20b 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-gpt-oss-20b.md
+- [x] hcx-007 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-hcx-007.md
+- [x] hcx-dash-002 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-hcx-dash-002.md
+
+## 판단 / 고민
+- 4가지 모델 모두 공식 안내 페이지에 구체적 수치가 텍스트로 제시되어 있지 않아 점수 등록을 스킵하고 이슈 티켓으로 넘김.
+
+## 이슈 제기
+- issues/2026-05-29-collect-benchmark-gpt-oss-120b.md
+- issues/2026-05-29-collect-benchmark-gpt-oss-20b.md
+- issues/2026-05-29-collect-benchmark-hcx-007.md
+- issues/2026-05-29-collect-benchmark-hcx-dash-002.md


### PR DESCRIPTION
Attempted to match benchmark scores for newly added LLM models (GPT-OSS-120B, GPT-OSS-20B, HCX-007, HCX-DASH-002). No official benchmark scores were found on their respective pricing/announcement pages, so issue tickets were created in `src/data/issues/` and the journal file `src/data/journal/2026-05-28-collect-benchmark.md` was updated.

---
*PR created automatically by Jules for task [2205410068219509892](https://jules.google.com/task/2205410068219509892) started by @GGJJack*