### PR TITLE
docs: publish daily report for 2026-05-28

### DIFF
--- a/src/data/journal/2026-05-29-journal.md
+++ b/src/data/journal/2026-05-29-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-29
+agent: journal
+status: completed
+summary: "2026-05-28 데일리 리포트 발행"
+---
+
+## 수행한 작업
+- [x] 2026-05-28 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark, reinforce 저널을 취합하여 데일리 리포트 작성 및 `src/data/updates/2026-05-28-daily.md` 로 발행 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-28-daily.md
+++ b/src/data/updates/2026-05-28-daily.md
@@ -1,0 +1,46 @@
+---
+date: 2026-05-28
+type: note
+title: 데일리 리포트 · 2026-05-28
+summary: "신규 LLM 모델 (Grok Build 0.1, Qwen3-Coder-480B-A35B-Instruct, HCX-005, GPT-OSS-120B, GPT-OSS-20B, HCX-007, HCX-DASH-002) 벤치마크 점수 매칭 시도 및 이슈 생성 / aime-2025, seccodebench-gen 상세 페이지 작성 완료 및 기관 스텁 생성"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 내용 없음
+
+### 벤치마크 (collect-benchmark)
+- 신규 등록된 LLM 모델의 벤치마크 점수 검색
+- 점수 미발견 시 이슈 티켓 생성
+- grok-build-0.1 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-28-collect-benchmark-grok-build-0.1.md
+- qwen3-coder-480b-instruct 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md
+- hcx-005 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-28-collect-benchmark-hcx-005.md
+- 전날 신규 등록된 LLM 모델(GPT-OSS-120B, GPT-OSS-20B, HCX-007, HCX-DASH-002)의 벤치마크 점수 검색 및 매칭 시도
+- gpt-oss-120b 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-gpt-oss-120b.md
+- gpt-oss-20b 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-gpt-oss-20b.md
+- hcx-007 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-hcx-007.md
+- hcx-dash-002 벤치마크 부재로 이슈 티켓 생성 ← issues/2026-05-29-collect-benchmark-hcx-dash-002.md
+
+## 상세 페이지 작성 (profile)
+- Create profile for `hcx-005`
+- Create profile for `gpt-oss-20b`
+- Validate with `bun run build`
+- aime-2025 프로필 작성
+- seccodebench-gen 프로필 작성
+- `src/content/benchmarks/aime-2025.md` 작성 완료 ← https://en.wikipedia.org/wiki/American_Invitational_Mathematics_Examination
+- `src/content/organizations/maa.md` 스텁 생성 완료
+- `src/content/benchmarks/seccodebench-gen.md` 작성 완료 ← https://github.com/alibaba/sec-code-bench
+- `src/content/organizations/alibaba.md` 스텁 생성 완료
+
+## 이슈 처리 (reinforce)
+- 내용 없음
+
+## 미해결 이슈
+- issues/2026-05-28-collect-benchmark-grok-build-0.1.md — grok-build-0.1 벤치마크 부재로 이슈 티켓 생성
+- issues/2026-05-28-collect-benchmark-qwen3-coder-480b-instruct.md — qwen3-coder-480b-instruct 벤치마크 부재로 이슈 티켓 생성
+- issues/2026-05-28-collect-benchmark-hcx-005.md — hcx-005 벤치마크 부재로 이슈 티켓 생성
+- issues/2026-05-29-collect-benchmark-gpt-oss-120b.md — gpt-oss-120b 벤치마크 부재로 이슈 티켓 생성
+- issues/2026-05-29-collect-benchmark-gpt-oss-20b.md — gpt-oss-20b 벤치마크 부재로 이슈 티켓 생성
+- issues/2026-05-29-collect-benchmark-hcx-007.md — hcx-007 벤치마크 부재로 이슈 티켓 생성
+- issues/2026-05-29-collect-benchmark-hcx-dash-002.md — hcx-dash-002 벤치마크 부재로 이슈 티켓 생성


### PR DESCRIPTION
- Read `2026-05-28` journal files for `collect-benchmark`, `profile-model`, and `profile-benchmark` and parsed their activities.
- Created `src/data/updates/2026-05-28-daily.md` with a summary and lists of tasks performed grouped by task.
- Created `src/data/journal/2026-05-29-journal.md` marking the journal agent's execution as completed.
- Passed local tests via `bun run build`.

---
*PR created automatically by Jules for task [7497017563201149867](https://jules.google.com/task/7497017563201149867) started by @GGJJack*