### PR TITLE
collect-benchmark: process new models and raise issues for missing official benchmark scores

### DIFF
--- a/src/data/issues/2026-05-29-collect-benchmark-command-a-plus.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-command-a-plus.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: major
+target: llm/command-a-plus-05-2026
+---
+
+## 상황
+Cohere Command A+ 모델의 벤치마크 점수가 블로그 글(https://cohere.com/blog/command-a-plus)에 그래프 이미지로만 기재되어 있어, 정확한 텍스트 기반 수치를 추출할 수 없습니다.
+
+## 시도한 것
+- 공식 블로그 및 Artificial Analysis 기사 탐색.
+
+## 요청
+- reinforce 에이전트가 Command A+ 모델의 벤치마크 평가 점수 표나 명확한 텍스트 수치가 있는 출처를 찾아 등록해주시기 바랍니다.

--- a/src/data/issues/2026-05-29-collect-benchmark-gpt-oss.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-gpt-oss.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: major
+target: llm/gpt-oss-120b
+---
+
+## 상황
+OpenAI의 gpt-oss-120b 모델의 벤치마크 점수를 공식적으로 확인할 수 있는 URL(예: https://openai.com/index/introducing-gpt-oss/)을 찾지 못했습니다. Vellum.ai 커뮤니티에서 o3와 비교한 분석 자료가 있지만, 공식 문서 접근이 차단되어 정확한 점수(LiveCodeBench 등)를 추출하기 어렵습니다.
+
+## 시도한 것
+- Google Search 및 OpenAI 뉴스 페이지에서 gpt-oss 관련 점수 검색. curl 등으로 openai.com/news를 페치하려 하였으나 정보를 추출하지 못함.
+
+## 요청
+- reinforce 에이전트가 공식 출처(OpenAI 사이트나 아카이브 등)를 통해 gpt-oss-120b 모델의 평가 점수를 수집하여 벤치마크로 등록해주시기 바랍니다.

--- a/src/data/issues/2026-05-29-collect-benchmark-grok-build.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-grok-build.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: major
+target: llm/grok-build-0.1
+---
+
+## 상황
+xAI의 Grok Build 0.1 모델에 대한 공식 벤치마크 점수가 기재된 문서를 발견하지 못했습니다. 공식 블로그(https://x.ai/news/grok-build-cli) 내용에는 벤치마크 평가 수치가 없습니다.
+
+## 시도한 것
+- https://x.ai/news/grok-build-cli 페이지 내용 텍스트 긁기 및 Grok Build 0.1 벤치마크 점수 탐색.
+
+## 요청
+- reinforce 에이전트가 Grok Build 0.1에 대한 공식 또는 커뮤니티 벤치마크 평가 수치를 찾아 등록해주기 바랍니다.

--- a/src/data/issues/2026-05-29-collect-benchmark-hcx.md
+++ b/src/data/issues/2026-05-29-collect-benchmark-hcx.md
@@ -1,0 +1,15 @@
+---
+created: 2026-05-29
+agent: collect-benchmark
+severity: minor
+target: llm/hcx-007
+---
+
+## 상황
+NAVER Cloud의 신규 모델들(HCX-007, HCX-DASH-002, HCX-005)에 대한 벤치마크 평가 점수(LogicKor, KMMLU 등)를 확인하지 못했습니다. 공식 안내 페이지(https://www.ncloud.com/product/ai/clovaStudio) 등에 구체적인 수치가 없습니다.
+
+## 시도한 것
+- 관련 벤치마크 점수 Google Search
+
+## 요청
+- 네이버 클라우드 기술 블로그나 논문 등에서 HCX 신규 모델들의 벤치마크 점수를 찾아서 등록해주시기 바랍니다.

--- a/src/data/journal/2026-05-29-collect-benchmark.md
+++ b/src/data/journal/2026-05-29-collect-benchmark.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-29
+agent: collect-benchmark
+status: completed
+summary: "신규 LLM 벤치마크 미비 출처 이슈 등록"
+---
+
+## Todo
+- 신규 등록된 LLM 모델들의 벤치마크 점수 매칭 시도
+
+## 조사 내역
+- 16:50 Cohere Command A+ 모델 발표 블로그 확인 ← https://cohere.com/blog/command-a-plus
+- 16:52 Grok Build 0.1 관련 공식 문서 확인, 수치 없음 ← https://x.ai/news/grok-build-cli
+- 16:55 OpenAI gpt-oss-120b 정보 탐색 (Vellum.ai 커뮤니티 글 확인) ← https://www.vellum.ai/blog/analysis-openai-o3-vs-gpt-oss-120b
+- 17:00 Command A+ 커뮤니티 벤치마크 수치 탐색 ← https://artificialanalysis.ai/articles/cohere-launches-open-weights-model-command-a-more-than-a-year-since-the-command-a-release
+
+## 수행한 작업
+- (없음)
+
+## 판단 / 고민
+- OpenAI 공식 블로그에서 gpt-oss의 구체적인 점수가 확인되지 않아 이슈로 이월 처리함.
+- Grok Build, HCX-007, HCX-DASH-002, HCX-005 등의 모델들에 대한 벤치마크 수치도 쉽게 확인되지 않아 동일하게 이슈 티켓을 생성함.
+- Command A+의 경우 공식 블로그와 Artificial Analysis 기사에서 명확한 텍스트 벤치마크 수치를 추출하기 어려워 점수를 임의로 등록하지 않고 이슈를 생성하는 것이 안전함.
+
+## 이슈 제기
+- issues/2026-05-29-collect-benchmark-gpt-oss.md
+- issues/2026-05-29-collect-benchmark-grok-build.md
+- issues/2026-05-29-collect-benchmark-hcx.md
+- issues/2026-05-29-collect-benchmark-command-a-plus.md


### PR DESCRIPTION
Processed newly registered LLM models to match benchmark scores. However, official sources for GPT-OSS-120B, Grok Build, HCX models, and Command A+ lacked verifiable, exact text-based score metrics. Following strict guidelines to prevent data hallucination, no arbitrary data was saved to `llm.json`. Instead, detailed issue tickets were created in `src/data/issues/` for `reinforce` agents to investigate further, and these findings were recorded in the daily journal.

---
*PR created automatically by Jules for task [17641925443089871007](https://jules.google.com/task/17641925443089871007) started by @GGJJack*