### PR TITLE
Publish daily report for 2026-05-29 and complete journal

### DIFF
--- a/src/data/journal/2026-05-30-journal.md
+++ b/src/data/journal/2026-05-30-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-05-30
+agent: journal
+status: completed
+summary: "2026-05-29 데일리 리포트 발행"
+---
+
+## 수행한 작업
+- [x] 2026-05-29 일자 collect-llm, collect-benchmark, profile-model, profile-benchmark, reinforce 저널을 취합하여 데일리 리포트 작성 및 `src/data/updates/2026-05-29-daily.md` 로 발행 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-05-29-daily.md
+++ b/src/data/updates/2026-05-29-daily.md
@@ -1,0 +1,37 @@
+---
+date: 2026-05-29
+type: note
+title: 데일리 리포트 · 2026-05-29
+summary: "Created detailed profiles for Gemini 3.1 Flash TTS and Mistral Physics AI (Emmi). / 신규 벤치마크 2건(deepsearchqa, terminal-bench-hard) 상세 페이지 작성 완료..."
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 보강: gpt-oss-120b, gpt-oss-20b · contextWindow ← https://openai.com/news
+- 보강: deepseek-v4-pro, deepseek-v4-flash · pricing ← https://api-docs.deepseek.com/quick_start/pricing
+- 보강: deepseek-v4-preview · pricing 및 parameterSize ← https://api-docs.deepseek.com/quick_start/pricing
+- 보강: grok-4-3 · pricing 및 contextWindow ← https://docs.x.ai/developers/models
+- 보강: grok-build-0.1 · pricing ← https://x.ai/news/grok-build-0-1
+- 보강: gemini-3.5-flash, gemini-3-1-flash-lite · contextWindow ← https://ai.google.dev/gemini-api/docs/models
+- 보강: granite-4.1-30b, 8b, 3b · contextWindow ← https://www.ibm.com/granite/docs/models/granite4-1
+- 신규: gemini-3-1-flash-tts, mistral-physics-ai-emmi
+
+### 벤치마크 (collect-benchmark)
+- 내용 없음
+
+## 상세 페이지 작성 (profile)
+- models/gemini-3-1-flash-tts ← https://ai.google.dev/gemini-api/docs/models
+- models/mistral-physics-ai-emmi ← https://mistral.ai/news/introducing-physics-ai-at-mistral
+- benchmarks/deepsearchqa ← https://arxiv.org/abs/2601.20975
+- benchmarks/terminal-bench-hard · status=draft ← https://artificialanalysis.ai/evaluations/terminalbench-hard
+
+## 이슈 처리 (reinforce)
+- 내용 없음
+
+## 미해결 이슈
+- issues/2026-05-30-profile-benchmark-terminal-bench-hard.md — `terminal-bench-hard` 벤치마크의 공식 리포지토리(https://github.com/pro-...
+- issues/2026-05-29-collect-benchmark-gpt-oss.md — OpenAI의 gpt-oss-120b 모델의 벤치마크 점수를 공식적으로 확인할 수 있는 URL(예: http...
+- issues/2026-05-29-collect-benchmark-grok-build.md — xAI의 Grok Build 0.1 모델에 대한 공식 벤치마크 점수가 기재된 문서를 발견하지 못했습니다. 공...
+- issues/2026-05-29-collect-benchmark-hcx.md — NAVER Cloud의 신규 모델들(HCX-007, HCX-DASH-002, HCX-005)에 대한 벤치마크...
+- issues/2026-05-29-collect-benchmark-command-a-plus.md — Cohere Command A+ 모델의 벤치마크 점수가 블로그 글(https://cohere.com/blog...


### PR DESCRIPTION
Compiled yesterday's (2026-05-29) journal logs for collect-llm, profile, and reinforce agents into the user-facing `2026-05-29-daily.md` report, and created the `2026-05-30-journal.md` for this task's completion record, matching the KST date boundaries.

---
*PR created automatically by Jules for task [3005131130894051396](https://jules.google.com/task/3005131130894051396) started by @GGJJack*