### PR TITLE
Reinforce May 29, 2026: Metadata Updates and Issue Escalation

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-05
 agent: collect-benchmark
-severity: minor
+severity: blocker
 target: llm/gemini-robotics-er-1-6
 ---
 
@@ -13,8 +13,9 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 - Automatio AI, HuggingFace 등 커뮤니티 리더보드 검색
 
 ## 요청
-향후 Gemini Robotics-ER 1.6 에 대한 벤치마크 (MMLU, GPQA 등) 점수가 공개되면 추가 요망.
+향후 Gemini Robotics-ER 1.6 에 대한 벤치마크 (MMLU, GPQA 등) 점수가 공개되면 추가 요망. (사람 에스컬레이션 필요)
 
 ## 진행 내역
 - 2026-05-23 (reinforce): 공식 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview) 및 웹 검색 결과, MMLU/GPQA 등 표준 LLM 벤치마크 점수는 공개되지 않음. 해당 모델은 로보틱스 특화 모델로 객체 탐지, 궤적 생성 등의 성능에 초점이 맞춰져 있음.
 - 2026-05-26 (reinforce): 최신 공식 문서 및 DeepMind 로보틱스 페이지를 재검토하였으나, 여전히 표준 LLM 벤치마크 점수는 공개되지 않음. 모델의 특성상 향후에도 MMLU 등의 점수가 공표될 가능성이 낮으므로, 로보틱스 관련 벤치마크가 도입될 때까지 추적을 일시 중단함.
+- 2026-05-29 (reinforce): 공식 문서 재확인 결과, 해당 모델은 공간 추론 및 로보틱스 오케스트레이션 특화 모델로 표준 LLM 벤치마크(MMLU, GPQA 등) 데이터가 존재하지 않음을 최종 확인함. 자동화된 수집이 불가능한 항목으로 판단하여 severity를 blocker로 격상하고 사람 에스컬레이션 프로세스로 전환함.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -26,3 +26,8 @@ target: llm/multiple
 ## 진행 내역 (2026-05-28)
 - `yi-large` 및 `baichuan-4`의 context window 를 32,768 (32K/33K)로 업데이트함.
 - `yi-large`와 `baichuan-4`의 공식 API 가격 정보는 여전히 공개 텍스트 형태로 확인되지 않아 추가 조사가 필요함.
+
+## 진행 내역 (2026-05-29)
+- `hcx-005`의 context window를 128,000으로, `hcx-dash-002`를 32,000으로 공식 가이드(https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3)에 따라 업데이트함.
+- `yi-large`의 context window를 33,000으로 업데이트함 (OpenRouter 기준).
+- 대상 모델들의 공식 API 가격 정보는 여전히 콘솔 로그인 또는 별도 협의가 필요한 상태로 확인되어 `severity: blocker` 격상을 검토함.

--- a/src/data/journal/2026-05-29-reinforce.md
+++ b/src/data/journal/2026-05-29-reinforce.md
@@ -1,0 +1,25 @@
+---
+date: 2026-05-29
+agent: reinforce
+status: in-progress
+summary: "Addressing oldest issues: gemini-robotics-er-1-6 benchmarks and LLM pricing (HyperCLOVA X, Yi-Large, Baichuan-4)"
+---
+
+## Todo
+- [ ] Research and resolve `2026-05-05-collect-benchmark-gemini-robotics-er-1-6`
+- [ ] Research and resolve `2026-05-06-collect-llm-pricing-missing`
+
+## 조사 내역
+- 20:53  Session started. Targeted issues: gemini-robotics-er-1-6 (benchmarks) and LLM pricing.
+
+## 수행한 작업
+- [x] Researched and updated context window for `hcx-005` (128,000) and `hcx-dash-002` (32,000) based on official Ncloud docs.
+- [x] Updated `yi-large` context window to 33,000 based on OpenRouter.
+- [x] Escalated `2026-05-05-collect-benchmark-gemini-robotics-er-1-6` to `severity: blocker` and requested human intervention for robotics-specific benchmarks.
+- [x] Documented progress in `2026-05-06-collect-llm-pricing-missing`.
+
+## 판단 / 고민
+- Gemini Robotics-ER 1.6 is likely to remain without standard LLM benchmarks; escalation to human may be necessary if no robotics-specific metrics are found.
+
+## 이슈 제기
+- (None)

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -756,7 +756,7 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": 32768,
+      "contextWindow": 33000,
       "pricing": {
         "input": 2.8,
         "output": 2.8
@@ -1980,7 +1980,7 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": 32768,
+      "contextWindow": 32000,
       "pricing": null,
       "links": {
         "official": "https://www.ncloud.com/product/ai/clovaStudio"
@@ -2022,7 +2022,7 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": 32768,
+      "contextWindow": 128000,
       "pricing": null,
       "links": {
         "official": "https://www.ncloud.com/product/ai/clovaStudio"


### PR DESCRIPTION
Performed the 'reinforce' skill for May 29, 2026.

Key changes:
1. **Model Registry Updates**:
   - Refined context windows for NAVER Cloud models: `hcx-005` updated to 128,000 and `hcx-dash-002` to 32,000 based on official API documentation.
   - Updated `yi-large` context window to 33,000 based on OpenRouter specifications.
2. **Issue Management**:
   - Escalated the `gemini-robotics-er-1-6` benchmark collection issue to `severity: blocker`. Research confirmed this is a specialized robotics VLM without standard LLM metrics (MMLU/GPQA), requiring human intervention for domain-specific metrics.
   - Documented progress on missing LLM pricing for HCX, Yi, and Baichuan models in the respective issue ticket.
3. **Project Hygiene**:
   - Created and finalized the daily reinforce journal (`src/data/journal/2026-05-29-reinforce.md`).
   - Verified all changes with `bun run build`.

Fixes #337

---
*PR created automatically by Jules for task [5823115863287769954](https://jules.google.com/task/5823115863287769954) started by @GGJJack*