### PR TITLE
reinforce · 2026-05-30 (updated pricing and benchmarks)

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -1632,6 +1632,34 @@
         "date": "2023-09-06",
         "source": "official"
       }
+    },
+    "sakana-fugu-mini": {
+      "gpqa": {
+        "value": 92.4,
+        "date": "2026-04-24",
+        "source": "official",
+        "sourceUrl": "https://sakana.ai/fugu-beta/"
+      },
+      "livecodebench-v6": {
+        "value": 90.4,
+        "date": "2026-04-24",
+        "source": "official",
+        "sourceUrl": "https://sakana.ai/fugu-beta/"
+      }
+    },
+    "sakana-fugu-ultra": {
+      "gpqa": {
+        "value": 95.1,
+        "date": "2026-04-24",
+        "source": "official",
+        "sourceUrl": "https://sakana.ai/fugu-beta/"
+      },
+      "livecodebench-v6": {
+        "value": 93.2,
+        "date": "2026-04-24",
+        "source": "official",
+        "sourceUrl": "https://sakana.ai/fugu-beta/"
+      }
     }
   }
 }

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-06
 agent: collect-llm
-severity: minor
+severity: blocker
 target: llm/multiple
 ---
 
@@ -31,3 +31,8 @@ target: llm/multiple
 - `hcx-005`의 context window를 128,000으로, `hcx-dash-002`를 32,000으로 공식 가이드(https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3)에 따라 업데이트함.
 - `yi-large`의 context window를 33,000으로 업데이트함 (OpenRouter 기준).
 - 대상 모델들의 공식 API 가격 정보는 여전히 콘솔 로그인 또는 별도 협의가 필요한 상태로 확인되어 `severity: blocker` 격상을 검토함.
+
+## 진행 내역 (2026-05-30)
+- `yi-large`의 가격 정보를 $0.3/$0.3 (per 1M tokens)으로 업데이트함 (OpenRouter 기준).
+- `baichuan-4`의 가격 정보를 $1.4/$1.4 (per 1M tokens)으로 유지/확인함 (API 파트너사 정보 기반).
+- `hyperclova-x`(HCX-007, 005, DASH-002)의 공식 가격은 여전히 NCP 콘솔 외부에서 확인 불가능함. 해당 이슈는 사람 에스컬레이션이 필요한 것으로 판단하여 severity를 blocker로 격상함.

--- a/src/data/issues/2026-05-07-collect-llm-metadata-missing.md
+++ b/src/data/issues/2026-05-07-collect-llm-metadata-missing.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-07
 agent: collect-llm
-severity: minor
+severity: blocker
 target: llm/multiple
 ---
 
@@ -25,3 +25,9 @@ target: llm/multiple
 - 2026-05-07 (reinforce): Search performed for HyperCLOVA X, Yi-Large, and Baichuan-4; official pricing and context window updates not found.
 - 2026-05-09 (collect-llm): Additional search performed for the listed models including Sakana AI's Fugu series. Official pricing/context window for these models remains unconfirmed as of early May 2026. Updated `yi-lightning`, `grok` family, and registered `gemini-deep-research`.
 - 2026-05-11 (reinforce): Sakana AI 모델들(Trinity, Namazu, TinySwallow)의 Context Window(128K~1M) 사양을 확인하여 업데이트 완료. API 가격 정보는 여전히 미공개 상태임.
+
+## 진행 내역 (2026-05-30)
+- `hyperclova-x`, `yi-large`, `baichuan-4` 관련 내역은 2026-05-06 티켓과 중복되어 해당 티켓에서 통합 관리함.
+- `gpt-5-5-instant` ($0.1/$0.4) 및 `alphaevolve` ($2/$12) 가격 정보는 최신 릴리스 기반으로 이미 반영되어 있음을 확인함.
+- `sakana-fugu-ultra/mini`의 벤치마크 점수를 공식 블로그(https://sakana.ai/fugu-beta/)를 통해 확인함. 가격 정보는 베타 단계로 공개되지 않음.
+- 주요 메타데이터가 보강되었으나 `hyperclova-x` 가격 정보가 여전히 누락되어 있으므로 blocker로 격상하여 관리함.

--- a/src/data/journal/2026-05-30-reinforce.md
+++ b/src/data/journal/2026-05-30-reinforce.md
@@ -1,0 +1,36 @@
+---
+date: 2026-05-30
+agent: reinforce
+status: completed
+summary: "Updated Yi-Large/Baichuan-4 pricing and Sakana Fugu benchmarks; escalated HCX issues to blocker"
+---
+
+## Todo
+- [x] Process 2026-05-06-collect-llm-pricing-missing.md
+- [x] Process 2026-05-07-collect-llm-metadata-missing.md
+
+## 조사 내역
+
+## 수행한 작업
+
+## 판단 / 고민
+
+## 이슈 제기
+
+## 조사 내역
+- 19:40 yi-large 가격 정보 확인 ($0.3/$0.3) ← https://openrouter.ai/models/01-ai/yi-large
+- 19:45 NAVER Cloud CLOVA Studio API 가이드 확인 (context window 128k/32k) ← https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3
+- 19:50 Sakana AI Fugu 모델 벤치마크 확인 ← https://sakana.ai/fugu-beta/
+
+## 수행한 작업
+- [x] yi-large 가격 정보 업데이트 ($0.3/$0.3)
+- [x] baichuan-4 가격 정보 확인 및 유지
+- [x] hyperclova-x 이슈 severity: blocker 격상 (공식 가격 확인 불가)
+
+## 수행한 작업 (추가)
+- [x] gpt-5-5-instant, alphaevolve 가격 정보 현행화 확인
+- [x] sakana-fugu-ultra/mini 벤치마크 출처 확인
+- [x] 2026-05-07 이슈 severity: blocker 격상 (HCX 가격 미결)
+
+## 수행한 작업 (벤치마크 추가)
+- [x] sakana-fugu-mini/ultra 벤치마크 점수 등록 (GPQA, LiveCodeBench v6)

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -758,8 +758,8 @@
       "parameterSize": null,
       "contextWindow": 33000,
       "pricing": {
-        "input": 2.8,
-        "output": 2.8
+        "input": 0.3,
+        "output": 0.3
       },
       "links": {
         "official": "https://www.01.ai/"


### PR DESCRIPTION
This PR reinforces the LLM model and benchmark registry by processing pending issue tickets from May 2026. 

Key changes:
1. **Pricing Updates**: Updated `yi-large` pricing to $0.3 per 1M tokens (input/output) using OpenRouter as a source. Verified `baichuan-4` pricing.
2. **Benchmark Scores**: Registered official GPQA and LiveCodeBench v6 scores for `sakana-fugu-mini` and `sakana-fugu-ultra` as announced in their April 24 blog post.
3. **Issue Escalation**: Escalated tickets regarding missing HyperCLOVA X pricing to `blocker` status, as official pay-as-you-go pricing remains restricted to console logins and cannot be programmatically verified.
4. **Journaling**: Documented all research and actions in `src/data/journal/2026-05-30-reinforce.md`.

Verified build integrity with `bun run build`.

Fixes #347

---
*PR created automatically by Jules for task [16684410017574363211](https://jules.google.com/task/16684410017574363211) started by @GGJJack*