### PR TITLE
Profile benchmarks: publish livecodebench-v6 and codeforces

### DIFF
--- a/src/content/benchmarks/codeforces.md
+++ b/src/content/benchmarks/codeforces.md
@@ -1,8 +1,8 @@
 ---
 benchmarkId: codeforces
 domain: llm
-status: draft
-updated: 2026-05-22
+status: published
+updated: 2026-05-31
 sources:
   - "https://en.wikipedia.org/wiki/Codeforces"
 organization: codeforces

--- a/src/content/benchmarks/livecodebench-v6.md
+++ b/src/content/benchmarks/livecodebench-v6.md
@@ -1,8 +1,8 @@
 ---
 benchmarkId: livecodebench-v6
 domain: llm
-status: draft
-updated: 2026-05-25
+status: published
+updated: 2026-05-31
 sources:
   - "https://arxiv.org/abs/2403.07974"
   - "https://livecodebench.github.io/"

--- a/src/data/issues/2026-06-01-profile-benchmark-codeforces-org.md
+++ b/src/data/issues/2026-06-01-profile-benchmark-codeforces-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-01
+agent: profile-benchmark
+severity: minor
+target: organization/codeforces
+---
+
+## 상황
+Codeforces 기관 페이지(`src/content/organizations/codeforces.md`)가 기본 정보만으로 `draft` 상태에 머물러 있습니다.
+
+## 시도한 것
+Wikipedia(en)의 Codeforces 문서를 기반으로 기존 내용을 검토했습니다. (https://en.wikipedia.org/wiki/Codeforces)
+
+## 요청
+Codeforces에 대한 추가적인 공식 출처(설립 연도, 주요 파트너십 등)를 조사하여 기관 페이지를 `published` 상태로 승격시켜 주시기 바랍니다.

--- a/src/data/journal/2026-05-31-profile-benchmark.md
+++ b/src/data/journal/2026-05-31-profile-benchmark.md
@@ -1,0 +1,27 @@
+---
+date: 2026-05-31
+agent: profile-benchmark
+status: completed
+summary: "livecodebench-v6 및 codeforces 벤치마크 상세 페이지 published 승격"
+---
+
+## Todo
+- [x] `livecodebench-v6` 검토 및 승격
+- [x] `codeforces` 검토 및 승격
+- [x] 관련 기관 스텁 점검 및 이슈 생성
+
+## 조사 내역
+- 17:55  `livecodebench-v6` 기존 문서 확인 및 `published` 승격 (문서 완성도 충분) ← https://livecodebench.github.io/
+- 17:58  `codeforces` 기존 문서 확인, Wikipedia(en) 출처 기반으로 검토 및 `published` 승격 ← https://en.wikipedia.org/wiki/Codeforces
+- 18:00  `codeforces` 기관 stub 검토 및 이슈 발행 대상 확인 ← https://en.wikipedia.org/wiki/Codeforces
+
+## 수행한 작업
+- [x] `livecodebench-v6.md` 상태 `published` 로 승격 ← https://livecodebench.github.io/
+- [x] `codeforces.md` 상태 `published` 로 승격 ← https://en.wikipedia.org/wiki/Codeforces
+
+## 판단 / 고민
+- Codeforces는 문서 내용이 이미 작성되어 있어 `published`로 상태 변경을 승인함.
+- 기관 스텁(`src/content/organizations/codeforces.md`)도 기존에 작성된 내용을 유지하며 상세 보강을 위해 이슈를 생성함.
+
+## 이슈 제기
+- issues/2026-06-01-profile-benchmark-codeforces-org.md


### PR DESCRIPTION
This PR promotes the `livecodebench-v6` and `codeforces` benchmark profiles from `draft` to `published` after reviewing their content.

It also includes the daily journal entry for `profile-benchmark` detailing the tasks performed, and logs a minor issue ticket to investigate the Codeforces organization stub for future reinforcement.

---
*PR created automatically by Jules for task [2160937314895739091](https://jules.google.com/task/2160937314895739091) started by @GGJJack*