### PR TITLE
docs: generate daily report for 2026-05-31

### DIFF
--- a/src/data/journal/2026-06-01-journal.md
+++ b/src/data/journal/2026-06-01-journal.md
@@ -1,0 +1,9 @@
+---
+date: 2026-06-01
+agent: journal
+status: completed
+summary: "2026-05-31 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- `src/data/journal/2026-05-31-*.md` 저널들을 종합하여 `src/data/updates/2026-05-31-daily.md` 리포트 발행.

--- a/src/data/updates/2026-05-31-daily.md
+++ b/src/data/updates/2026-05-31-daily.md
@@ -1,0 +1,38 @@
+---
+date: 2026-05-31
+type: note
+title: "데일리 리포트 · 2026-05-31"
+summary: "Claude Opus 4.8 등 신규 모델 4건 등록 및 Gemini 3.5 Flash 등 기존 모델 5건 보강 완료 / Claude Opus 4.8 및 Sakana Fugu Mini 상세 프로파일 작성 완료 / livecodebench-v6 및 codeforces 벤치마크 상세 페이지 published 승격 / Mistral Medium 3.5, HLE, Sakana Fugu 점수 보강 및 ETRI 프로필 업데이트 완료"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- [x] 신규 모델 등록: `claude-opus-4-8` (Anthropic, 2026-05-28) ← https://www.anthropic.com/news/claude-opus-4-8
+- [x] 신규 모델 등록: `nano-banana` (Google, 2026-05-19) ← https://deepmind.google/models/
+- [x] 신규 모델 등록: `gemini-audio` (Google, 2026-05-19) ← https://deepmind.google/models/
+- [x] 신규 모델 등록: `gemini-3-5-pro` (Google, 2026-06-01 예정) ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- [x] 기존 모델 보강: `gemini-3.5-flash` 공식 링크 및 기술 리포트 추가 ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- [x] 기존 모델 보강: `mistral-saba` 가격 정보($0.7/$0.7) 보강 ← (공식 문서 기반)
+- [x] 기존 모델 보강: `exaone-4-5-33b` 가격 정보($0.15/$0.6) 보강 ← (공식 문서 기반)
+- [x] 기존 모델 보강: `hcx-007` 가격 정보($0.5/$2.0) 보강 ← (NCP Clova Studio 기반)
+- [x] 기존 모델 보강: `mistral-medium-3-5` 릴리스 정보(2026-05-22) 및 메타데이터 보강 ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/
+
+### 벤치마크 (collect-benchmark)
+- (없음)
+
+## 상세 페이지 작성 (profile)
+- [x] `src/content/models/claude-opus-4-8.md` 신규 생성 및 작성 (status: published)
+- [x] `src/content/models/sakana-fugu-mini.md` 신규 생성 및 작성 (status: published)
+- [x] `livecodebench-v6.md` 상태 `published` 로 승격 ← https://livecodebench.github.io/
+- [x] `codeforces.md` 상태 `published` 로 승격 ← https://en.wikipedia.org/wiki/Codeforces
+
+## 이슈 처리 (reinforce)
+- 10:15 Mistral Medium 3.5 점수 등록 완료.
+- 10:40 HLE 점수 (11개 모델) 등록 완료. 이를 위해 o1, gpt-5 등 누락된 프론티어 모델 ID 생성.
+- 10:50 Sakana Fugu 모델 점수 보강 완료.
+- 11:00 ETRI 기관 상세 페이지 (`src/content/organizations/etri.md`) 업데이트 완료.
+- 11:10 해결된 이슈 티켓 (`2026-05-12-profile-benchmark-etri.md`, `2026-05-12-collect-benchmark-missing-scores.md`, `2026-05-10-collect-benchmark-missing-benchmarks.md`) 삭제.
+
+## 미해결 이슈
+- issues/2026-06-01-profile-benchmark-codeforces-org.md


### PR DESCRIPTION
I have fulfilled the user request to execute the `journal` skill. I generated the daily report for `2026-05-31` by extracting data across all sub-agent journals. The report was built using a Node.js script. I also created `2026-06-01-journal.md` to flag the daily task completion, complying with project requirements. Tests were fully verified via `bun install && bun run build`.

---
*PR created automatically by Jules for task [14482428379309895297](https://jules.google.com/task/14482428379309895297) started by @GGJJack*