### PR TITLE
feat(benchmarks): Create online-mind2web and legal-agent-bench profiles

### DIFF
--- a/src/content/benchmarks/legal-agent-bench.md
+++ b/src/content/benchmarks/legal-agent-bench.md
@@ -1,0 +1,16 @@
+---
+benchmarkId: legal-agent-bench
+domain: llm
+status: draft
+updated: 2026-06-02
+sources:
+  - https://hebbia.ai/
+---
+
+# Legal Agent Benchmark (법률 에이전트 벤치마크)
+
+## 개요
+에이전트의 법률 업무 수행 능력 평가
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/content/benchmarks/online-mind2web.md
+++ b/src/content/benchmarks/online-mind2web.md
@@ -1,0 +1,16 @@
+---
+benchmarkId: online-mind2web
+domain: llm
+status: draft
+updated: 2026-06-02
+sources:
+  - https://osu-nlp-group.github.io/Mind2Web/
+---
+
+# Online-Mind2Web
+
+## 개요
+웹 브라우저 상호작용 및 에이전트 능력 평가
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/data/issues/2026-06-02-profile-benchmark-legal-agent-bench-org.md
+++ b/src/data/issues/2026-06-02-profile-benchmark-legal-agent-bench-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-02
+agent: profile-benchmark
+severity: minor
+target: llm/legal-agent-bench
+---
+
+## 상황
+Legal Agent Benchmark 벤치마크를 등록했으나, 제작 기관(Hebbia 등) 정보를 공식적으로 확정하여 연결하기 어렵습니다.
+
+## 시도한 것
+https://hebbia.ai/ 사이트를 조사했으나 정확한 기관 ID를 추측하지 않기 위해 기관 생성을 생략했습니다.
+
+## 요청
+해당 벤치마크를 제작한 기관 페이지를 생성하고 벤치마크 파일(src/content/benchmarks/legal-agent-bench.md)의 organization 필드에 연결해 주세요.

--- a/src/data/issues/2026-06-02-profile-benchmark-online-mind2web-org.md
+++ b/src/data/issues/2026-06-02-profile-benchmark-online-mind2web-org.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-02
+agent: profile-benchmark
+severity: minor
+target: llm/online-mind2web
+---
+
+## 상황
+Online-Mind2Web 벤치마크를 등록했으나, 제작 기관 정보를 공식적으로 확정하여 연결하기 어렵습니다.
+
+## 시도한 것
+https://osu-nlp-group.github.io/Mind2Web/ 및 연관 논문을 조사했으나, 프로젝트에 등록된 정확한 기관 ID 매핑이 부족합니다.
+
+## 요청
+해당 벤치마크를 제작한 기관 페이지를 생성하고 벤치마크 파일(src/content/benchmarks/online-mind2web.md)의 organization 필드에 연결해 주세요.

--- a/src/data/journal/2026-06-01-profile-benchmark.md
+++ b/src/data/journal/2026-06-01-profile-benchmark.md
@@ -1,0 +1,24 @@
+---
+date: 2026-06-01
+agent: profile-benchmark
+status: completed
+summary: "Online-Mind2Web 및 Legal Agent Benchmark 상세 페이지 작성"
+---
+
+## Todo
+- 등록된 벤치마크 상세 페이지 작성 (Online-Mind2Web, Legal Agent Benchmark)
+
+## 조사 내역
+- 02:40 Online-Mind2Web 공식 페이지 조사 ← https://osu-nlp-group.github.io/Mind2Web/
+- 02:42 Hebbia(Legal Agent Benchmark) 공식 페이지 조사 ← https://hebbia.ai/
+
+## 수행한 작업
+- [x] `src/content/benchmarks/online-mind2web.md` 작성 ← https://osu-nlp-group.github.io/Mind2Web/
+- [x] `src/content/benchmarks/legal-agent-bench.md` 작성 ← https://hebbia.ai/
+
+## 판단 / 고민
+- 두 벤치마크 모두 제작 기관을 추측하여 ID를 생성하지 않고, 이슈 티켓을 만들어 처리하도록 했습니다.
+
+## 이슈 제기
+- issues/2026-06-02-profile-benchmark-online-mind2web-org.md
+- issues/2026-06-02-profile-benchmark-legal-agent-bench-org.md


### PR DESCRIPTION
This PR creates the profile markdown files for the `online-mind2web` and `legal-agent-bench` benchmarks.
Because the exact organization mapping information for these benchmarks was unverified or unclear from the official sources, organization stubs were omitted, and instead, issue tickets were created to track the missing organization assignments in `src/data/issues/`.
The task journal has also been recorded with the `completed` status for the session.

---
*PR created automatically by Jules for task [626291781492485149](https://jules.google.com/task/626291781492485149) started by @GGJJack*