### PR TITLE
docs(journal): publish 2026-06-01 daily report

### DIFF
--- a/src/data/journal/2026-06-02-journal.md
+++ b/src/data/journal/2026-06-02-journal.md
@@ -1,0 +1,9 @@
+---
+date: 2026-06-02
+agent: journal
+status: completed
+summary: "2026-06-01 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- `src/data/journal/2026-06-01-*.md` 저널들을 종합하여 `src/data/updates/2026-06-01-daily.md` 리포트 발행.

--- a/src/data/updates/2026-06-01-daily.md
+++ b/src/data/updates/2026-06-01-daily.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-01
+type: note
+title: 데일리 리포트 · 2026-06-01
+summary: "신규 벤치마크 3건 생성 및 기존 벤치마크 포함 총 4건의 점수 매칭 완료 (mistral-medium-3-5, claude-opus-4-8), 누락 점수는 이슈 생성 / Online-Mind2Web 및 Legal Agent Benchmark 상세 페이지 작성"
+---
+
+## 오늘의 수집
+
+### 벤치마크 (collect-benchmark)
+- 신규 등록된 LLM의 벤치마크 수치 확인 및 등록 (gemini-3.5-flash, mistral-medium-3-5, claude-opus-4-8)
+- 신규 벤치마크 등록: `online-mind2web`, `legal-agent-bench`, `charxiv-reasoning`, `cursor-bench`
+- `mistral-medium-3-5` 점수 추가: `swe-bench-verified` (77.6) ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/
+- `mistral-medium-3-5` 점수 추가: `tau-bench-telecom` (91.4) ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/
+- `claude-opus-4-8` 점수 추가: `online-mind2web` (84.0) ← https://www.anthropic.com/news/claude-opus-4-8
+- `claude-opus-4-8` 점수 추가: `legal-agent-bench` (10.0) ← https://www.anthropic.com/news/claude-opus-4-8
+
+## 상세 페이지 작성 (profile)
+- 등록된 벤치마크 상세 페이지 작성 (Online-Mind2Web, Legal Agent Benchmark)
+- `src/content/benchmarks/online-mind2web.md` 작성 ← https://osu-nlp-group.github.io/Mind2Web/
+- `src/content/benchmarks/legal-agent-bench.md` 작성 ← https://hebbia.ai/
+
+## 미해결 이슈
+- issues/2026-06-01-collect-benchmark-gemini-3.5-flash.md
+- issues/2026-06-01-collect-benchmark-claude-opus-4-8.md
+- issues/2026-06-02-profile-benchmark-online-mind2web-org.md
+- issues/2026-06-02-profile-benchmark-legal-agent-bench-org.md


### PR DESCRIPTION
This PR introduces the daily report for 2026-06-01.

**Changes Details:**
* Parsed and extracted relevant sections (e.g., Todo, 수행한 작업, 이슈 제기) from the `collect-benchmark` and `profile-benchmark` agent journals dated 2026-06-01.
* Generated the comprehensive daily report `src/data/updates/2026-06-01-daily.md` categorizing the updates strictly based on the journal entries and preserving source URLs as per the rules.
* Logged the journal task completion locally to `src/data/journal/2026-06-02-journal.md` setting its status to `completed`.
* Validated syntax via the schema validator by running `bun run build`.

---
*PR created automatically by Jules for task [11865127250843307392](https://jules.google.com/task/11865127250843307392) started by @GGJJack*