### PR TITLE
collect-benchmark: create issues for unverified scores in gemini-3.5-flash and claude-opus-4-8

### DIFF
--- a/src/data/issues/2026-06-02-collect-benchmark-claude-opus-4-8.md
+++ b/src/data/issues/2026-06-02-collect-benchmark-claude-opus-4-8.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-02
+agent: collect-benchmark
+severity: blocker
+target: llm/claude-opus-4-8
+---
+
+## 상황 Claude Opus 4.8 벤치마크 점수 부족
+공식 블로그(https://www.anthropic.com/news/claude-opus-4-8)에서 OSWorld-Verified 등의 벤치마크 점수를 텍스트에서 명확히 찾지 못했습니다.
+
+## 시도한 것
+공식 블로그를 탐색하였으나 본문에 명시된 82.3% 수치는 이전 모델(Opus 4.7)의 것이며 Opus 4.8의 수치들을 추출하기 어려웠습니다 (이미지 또는 System Card에 나와있을 가능성이 있음).
+
+## 요청
+Claude Opus 4.8의 OSWorld-Verified 등의 벤치마크 점수를 찾아 등록해주세요.

--- a/src/data/issues/2026-06-02-collect-benchmark-gemini-3.5-flash.md
+++ b/src/data/issues/2026-06-02-collect-benchmark-gemini-3.5-flash.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-02
+agent: collect-benchmark
+severity: blocker
+target: llm/gemini-3.5-flash
+---
+
+## 상황 Gemini 3.5 Flash 벤치마크 점수 누락
+공식 블로그(https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/)에서 Terminal-Bench 2.1, GDPval-AA, MCP Atlas, CharXiv Reasoning 등 여러 벤치마크 점수를 명확히 찾지 못했습니다.
+
+## 시도한 것
+공식 블로그의 텍스트 내용을 탐색했으나 해당 벤치마크 수치가 명시적으로 텍스트로 표기되어 있지 않습니다. (이미지 등에 포함되어 있을 수 있음)
+
+## 요청
+Gemini 3.5 Flash의 Terminal-Bench 2.1, GDPval-AA, MCP Atlas, CharXiv Reasoning 등의 정확한 점수를 찾아 등록해주세요.

--- a/src/data/journal/2026-06-02-collect-benchmark.md
+++ b/src/data/journal/2026-06-02-collect-benchmark.md
@@ -1,0 +1,26 @@
+---
+date: 2026-06-02
+agent: collect-benchmark
+status: completed
+summary: "신규 등록된 LLM의 벤치마크 점수 검증 (미등록된 수치에 대한 이슈 생성)"
+---
+
+## Todo
+- 신규 등록된 LLM의 벤치마크 수치 확인 및 매칭. (어제 또는 오늘 수집된 모델)
+
+## 조사 내역
+- 01:30 Google Gemini 3.5 블로그 검증. ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+  - 본문 텍스트에서 Terminal-Bench 2.1, GDPval-AA, MCP Atlas, CharXiv Reasoning 등 벤치마크 이름은 언급되나 구체적인 수치는 텍스트로 명확히 적혀있지 않음을 확인. Groundedness Rule에 따라 점수 등록 안 함.
+- 01:35 Anthropic Claude Opus 4.8 블로그 검증. ← https://www.anthropic.com/news/claude-opus-4-8
+  - 본문 텍스트에서 OSWorld-Verified 점수 확인 시도. "Opus 4.7 score to 82.3%" 문구만 존재하고 Opus 4.8의 점수는 텍스트에 없음. Groundedness Rule에 따라 점수 등록 안 함.
+
+## 수행한 작업
+- [x] (추가된 점수 없음 - 텍스트 기반 수치 미확인)
+
+## 판단 / 고민
+- Gemini 3.5 Flash와 Claude Opus 4.8의 누락된 벤치마크 점수들은 모두 블로그 본문 텍스트에 명확한 수치로 존재하지 않는 것을 재차 확인.
+- 명시된 규칙 "출처 URL 없는 필드는 저장하지 말고 src/data/issues/ 에 티켓 생성" 에 따라 관련된 이슈 티켓을 생성하기로 결정함.
+
+## 이슈 제기
+- issues/2026-06-02-collect-benchmark-gemini-3.5-flash.md
+- issues/2026-06-02-collect-benchmark-claude-opus-4-8.md


### PR DESCRIPTION
Created missing score issues for Gemini 3.5 Flash and Claude Opus 4.8. These scores were not available in the text of the official announcements and were likely embedded in images or omitted. Added a journal entry detailing the investigation and the decision to omit the scores to comply with the groundedness rules.

---
*PR created automatically by Jules for task [7039015764205355529](https://jules.google.com/task/7039015764205355529) started by @GGJJack*