### PR TITLE
Publish daily report for 2026-06-02

### DIFF
--- a/src/data/journal/2026-06-03-journal.md
+++ b/src/data/journal/2026-06-03-journal.md
@@ -1,0 +1,9 @@
+---
+date: 2026-06-03
+agent: journal
+status: completed
+summary: "2026-06-02 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- `src/data/journal/2026-06-02-*.md` 저널들을 종합하여 `src/data/updates/2026-06-02-daily.md` 리포트 발행.

--- a/src/data/updates/2026-06-02-daily.md
+++ b/src/data/updates/2026-06-02-daily.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-02
+type: note
+title: "데일리 리포트 · 2026-06-02"
+summary: "신규 모델 5건 등록, 6건 보강, 상세 페이지 4건 작성, 이슈 2건 제기"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 보강: Gemini 3.5 Pro (Google) · contextWindow(2,000,000) 업데이트. ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- 보강: Gemini 2.5 Pro (Google) · contextWindow(2,000,000), pricing(input: 1.25, output: 10) 업데이트. ← https://ai.google.dev/pricing
+- 보강: Gemini 2.5 Flash (Google) · contextWindow(1,000,000), pricing(input: 0.3, output: 2.5) 업데이트. ← https://ai.google.dev/pricing
+- 보강: Nano Banana (Google) · contextWindow(128,000), pricing(input: 0.1, output: 0.4) 업데이트. ← https://ai.google.dev/pricing
+- 보강: Mistral Medium 3.5 (Mistral AI) · parameterSize(128B), contextWindow(256,000), pricing(input: 1.5, output: 7.5) 업데이트. ← https://mistral.ai/pricing/,
+- 보강: Magistral Medium 1.2 (Mistral AI) · contextWindow(128,000) 업데이트. ← https://docs.mistral.ai/getting-started/models/
+- 신규: Magistral Small 1.2 (Mistral AI) · 2025-09 출시(v25.09), 128k context, $0.5/$1.5 pricing. ← https://mistral.ai/pricing/
+- 신규: Mistral Moderation 2 (Mistral AI) · 2026-03 출시(v26.03), 128k context, $0.1/$0.1 pricing. ← https://mistral.ai/pricing/
+- 신규: Mistral Small Creative (Mistral AI) · 2025-12 출시(v25.12), 128k context, $0.1/$0.3 pricing. ← https://mistral.ai/pricing/
+- 신규: Gemini 3 Pro Image (Google) · 2026-04-22 출시, $2/$12 pricing. ← https://ai.google.dev/pricing
+- 신규: Gemini 3.1 Flash Image (Google) · 2026-04-22 출시, $0.5/$3 pricing. ← https://ai.google.dev/pricing
+
+### 벤치마크 (collect-benchmark)
+- 내역 없음
+
+## 상세 페이지 작성 (profile)
+- benchmarks/charxiv-reasoning · status=published ← https://arxiv.org/abs/2406.18521v1
+- benchmarks/cursor-bench · status=draft ← https://lushbinary.com/blog/cursor-composer-2-5-developer-guide-benchmarks-pricing/
+- models/o3-mini · status=published
+- models/gpt-5 · status=published
+
+## 이슈 처리 (reinforce)
+- 내역 없음
+
+## 미해결 이슈
+- issues/2026-06-02-collect-benchmark-gemini-3.5-flash.md — Gemini 3.5 Flash 벤치마크 점수 누락
+- issues/2026-06-02-collect-benchmark-claude-opus-4-8.md — Claude Opus 4.8 벤치마크 점수 부족


### PR DESCRIPTION
Generates the daily report for 2026-06-02 by extracting the activity data from yesterday's completed collect-llm, collect-benchmark, profile-model, and profile-benchmark journals. Creates a new journal entry to mark the daily report task as complete.

---
*PR created automatically by Jules for task [4339692031838695672](https://jules.google.com/task/4339692031838695672) started by @GGJJack*