### PR TITLE
docs: generate daily report for 2026-06-03

### DIFF
--- a/src/data/journal/2026-06-04-journal.md
+++ b/src/data/journal/2026-06-04-journal.md
@@ -1,0 +1,9 @@
+---
+date: 2026-06-04
+agent: journal
+status: completed
+summary: "2026-06-03 데일리 리포트 발행 완료"
+---
+
+## 수행한 작업
+- `src/data/journal/2026-06-03-*.md` 저널들을 종합하여 `src/data/updates/2026-06-03-daily.md` 리포트 발행 완료.

--- a/src/data/updates/2026-06-03-daily.md
+++ b/src/data/updates/2026-06-03-daily.md
@@ -1,0 +1,43 @@
+---
+date: 2026-06-03
+type: note
+title: "데일리 리포트 · 2026-06-03"
+summary: "LLM 5건 신규 발견 및 6건 보강, 벤치마크 프로필 2건 published 승격"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: Gemini Omni  (Google)
+- 신규: Composer 2.5  (xAI)
+- 신규: Qwen3.5-2B  (Alibaba Cloud)
+- 신규: Mercury 2  (Inception Labs)
+- 신규: Step 3.7 Flash  (StepFun)
+- 보강: Gemini 3.5 Pro  (Google)
+- 보강: Gemini 3 Pro  (Google)
+- 보강: Claude 4.5 Sonnet  (Anthropic)
+- 보강: Grok 4  (xAI)
+- 보강: Gemini 2.5 Pro  (Google)
+- 보강: Gemini 2.5 Flash  (Google)
+
+### 벤치마크 (collect-benchmark)
+(신규 벤치마크 수집 없음)
+
+## 상세 페이지 작성 (profile)
+- benchmarks/online-mind2web · status=published
+- benchmarks/scicode · status=published
+
+## 이슈 처리 (reinforce)
+(이슈 처리 없음)
+
+## 미해결 이슈
+- issues/2026-06-04-collect-benchmark-gemini-2-5-pro.md
+- issues/2026-06-04-collect-benchmark-gemini-2-5-flash.md
+- issues/2026-06-04-collect-benchmark-nano-banana.md
+- issues/2026-06-04-collect-benchmark-magistral-medium-1-2.md
+- issues/2026-06-04-collect-benchmark-magistral-small-1-2.md
+- issues/2026-06-04-collect-benchmark-mistral-moderation-2.md
+- issues/2026-06-04-collect-benchmark-mistral-small-creative.md
+- issues/2026-06-04-collect-benchmark-gemini-3-pro-image.md
+- issues/2026-06-04-collect-benchmark-gemini-3-1-flash-image.md
+- issues/2026-06-04-collect-benchmark-gemini-3-5-pro.md


### PR DESCRIPTION
Generated the daily report for `2026-06-03` by aggregating the data from the `collect-llm`, `collect-benchmark`, and `profile-benchmark` journals. Also created the current day's (`2026-06-04`) journal file to log the completion of this task with the `status: completed` frontmatter set, following the defined `journal` skill rules.

---
*PR created automatically by Jules for task [9395860881272352108](https://jules.google.com/task/9395860881272352108) started by @GGJJack*