### PR TITLE
feat: execute collect-benchmark cycle for 2026-06-05

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -546,6 +546,20 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "lifescibench",
+      "name": "LifeSciBench",
+      "nameKo": "LifeSciBench",
+      "category": "reasoning",
+      "description": "Foundational aspects in life sciences research: evidence handling, analysis, design and optimization, scientific reasoning, validation and operations, and translation and communication.",
+      "source": "https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {

--- a/src/data/issues/2026-06-05-collect-benchmark-gpt-rosalind.md
+++ b/src/data/issues/2026-06-05-collect-benchmark-gpt-rosalind.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-05
+agent: collect-benchmark
+severity: minor
+target: llm/gpt-rosalind
+---
+
+## 상황
+`gpt-rosalind` 모델의 `lifescibench` 벤치마크 점수를 수집하려 했으나, 공식 출처(https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/)의 텍스트에서 명시적인 수치를 확인할 수 없습니다.
+
+## 시도한 것
+Google Search를 통해 공식 블로그 포스트의 스니펫을 확인했으나 텍스트로 된 점수를 확보하지 못했습니다.
+
+## 요청
+공식 문서나 기타 신뢰할 수 있는 출처를 통해 `gpt-rosalind`의 `lifescibench` 점수를 확인할 수 있는 텍스트 기반 수치가 있는지 확인하고 점수를 등록해 주세요.

--- a/src/data/issues/2026-06-05-collect-benchmark-rosalind-biodefense.md
+++ b/src/data/issues/2026-06-05-collect-benchmark-rosalind-biodefense.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-05
+agent: collect-benchmark
+severity: minor
+target: llm/rosalind-biodefense
+---
+
+## 상황
+`rosalind-biodefense` 모델의 최신 벤치마크 점수를 수집하려 했으나, 공식 출처 텍스트에서 명시적인 수치를 확인할 수 없습니다.
+
+## 시도한 것
+관련 출처 및 OpenAI 공식 사이트를 조사하였으나 명시적인 벤치마크 점수를 찾지 못했습니다.
+
+## 요청
+공식 문서나 기타 신뢰할 수 있는 출처를 통해 `rosalind-biodefense`의 벤치마크 점수를 확인할 수 있는 텍스트 기반 수치가 있는지 확인하고 점수를 등록해 주세요.

--- a/src/data/journal/2026-06-05-collect-benchmark.md
+++ b/src/data/journal/2026-06-05-collect-benchmark.md
@@ -1,0 +1,24 @@
+---
+title: "2026-06-05 collect-benchmark Journal"
+updated: "2026-06-05T01:30:00Z"
+status: completed
+---
+
+## Todo
+- [ ] Register new benchmark LifeSciBench
+- [ ] Attempt to match benchmark scores for gpt-rosalind and rosalind-biodefense
+- [ ] Create issue tickets if explicit text-verifiable scores are not found
+
+## 조사 내역
+- 01:30 LifeSciBench 등록 및 gpt-rosalind 점수 탐색 시도 ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+
+## 수행한 작업
+- [x] 신규 벤치마크 등록: LifeSciBench
+- [x] gpt-rosalind 및 rosalind-biodefense 점수 검색 시도 (명시적 수치 확인 불가)
+
+## 판단 / 고민
+- 공식 출처에서 명시적 텍스트로 된 점수가 확인되지 않아 이슈 티켓으로 생성함.
+
+## 이슈 제기
+- issues/2026-06-05-collect-benchmark-gpt-rosalind.md
+- issues/2026-06-05-collect-benchmark-rosalind-biodefense.md


### PR DESCRIPTION
Executed the 2026-06-05 `collect-benchmark` cycle. Discovered new benchmark (`LifeSciBench`) for new models (`gpt-rosalind` and `rosalind-biodefense`). Registered the definition but since explicit numeric text scores were unavailable in the parsed texts, created issues in `src/data/issues/` per rules rather than recording hallucinated scores.

---
*PR created automatically by Jules for task [7089237535375005126](https://jules.google.com/task/7089237535375005126) started by @GGJJack*