### PR TITLE
Add LifeSciBench profile page

### DIFF
--- a/src/content/benchmarks/lifescibench.md
+++ b/src/content/benchmarks/lifescibench.md
@@ -1,0 +1,19 @@
+---
+benchmarkId: lifescibench
+domain: llm
+status: draft
+updated: 2026-06-05
+sources:
+  - https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+organization: openai
+highlights:
+  - "Foundational aspects in life sciences research: evidence handling, analysis, design and optimization, scientific reasoning, validation and operations, and translation and communication."
+---
+
+# LifeSciBench
+
+## 개요
+Foundational aspects in life sciences research: evidence handling, analysis, design and optimization, scientific reasoning, validation and operations, and translation and communication.
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/data/journal/2026-06-05-profile-benchmark.md
+++ b/src/data/journal/2026-06-05-profile-benchmark.md
@@ -1,0 +1,17 @@
+---
+title: "2026-06-05 profile-benchmark Journal"
+status: completed
+updated: 2026-06-05
+---
+
+## Todo
+- [ ] LifeSciBench 상세 페이지 작성
+
+## 조사 내역
+- 02:30 LifeSciBench 정보 확인 ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+## 수행한 작업
+- [x] LifeSciBench 상세 페이지 (`src/content/benchmarks/lifescibench.md`) 작성 완료 ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+## 판단 / 고민
+- 공식 출처와 JSON 데이터를 바탕으로 본문을 작성하였음.
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Created the missing `lifescibench` benchmark profile page using the latest context from the registered sources and logged the execution in the journal.

---
*PR created automatically by Jules for task [14770014935895707569](https://jules.google.com/task/14770014935895707569) started by @GGJJack*