### PR TITLE
collect-benchmark: 2026-06-07 updates

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -1974,6 +1974,20 @@
         "source": "official",
         "url": "https://openai.com/index/introducing-gpt-rosalind/"
       }
+    },
+    "glm-5": {
+      "swe-bench-verified": {
+        "value": 77.8,
+        "date": "2026-06-07",
+        "source": "official",
+        "url": "https://www.zhipuai.cn/news"
+      },
+      "terminal-bench-2-0": {
+        "value": 56.2,
+        "date": "2026-06-07",
+        "source": "official",
+        "url": "https://www.zhipuai.cn/news"
+      }
     }
   }
 }

--- a/src/data/issues/2026-06-07-collect-benchmark-gemini-omni-pro.md
+++ b/src/data/issues/2026-06-07-collect-benchmark-gemini-omni-pro.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-07
+agent: collect-benchmark
+severity: minor
+target: llm/gemini-omni-pro
+---
+
+## 상황
+`gemini-omni-pro` 모델의 공식 페이지(https://deepmind.google/models/gemini-omni/)에 구체적인 벤치마크 점수가 텍스트로 존재하지 않음.
+
+## 시도한 것
+공식 소개 페이지 텍스트 분석.
+
+## 요청
+공식 기술 보고서 또는 추가 문서에서 벤치마크 점수 확인 필요.

--- a/src/data/issues/2026-06-07-collect-benchmark-glm-4-7-pro.md
+++ b/src/data/issues/2026-06-07-collect-benchmark-glm-4-7-pro.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-07
+agent: collect-benchmark
+severity: minor
+target: llm/glm-4-7-pro
+---
+
+## 상황
+`glm-4-7-pro` 모델의 점수를 찾고자 Zhipu AI 뉴스 페이지(https://www.zhipuai.cn/news)를 확인했으나, `GLM-5`의 일부 벤치마크 점수만 확인되고 `glm-4-7-pro`의 점수는 발견되지 않음.
+
+## 시도한 것
+뉴스 페이지 텍스트에서 벤치마크/점수 추출.
+
+## 요청
+`glm-4-7-pro` 의 벤치마크 점수 공식 발표 시 업데이트 필요.

--- a/src/data/issues/2026-06-07-collect-benchmark-solar-pro-2.md
+++ b/src/data/issues/2026-06-07-collect-benchmark-solar-pro-2.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-07
+agent: collect-benchmark
+severity: minor
+target: llm/solar-pro-2
+---
+
+## 상황
+`solar-pro-2` 및 `solar-pro-2-preview` 모델의 공식 블로그(https://www.upstage.ai/blog/en/solar-pro-2-launch 등)에서 MMLU, HumanEval 등의 벤치마크 이름은 언급되나, 구체적인 점수(숫자)가 명시되어 있지 않아 수집이 불가능함.
+
+## 시도한 것
+공식 블로그 내용 스크래핑 후 점수 패턴 정규식 매칭.
+
+## 요청
+추후 공식 기술 문서나 리더보드 등에서 `solar-pro-2` 의 벤치마크 점수 확인 필요.

--- a/src/data/issues/2026-06-07-collect-benchmark-step-3-7-pro.md
+++ b/src/data/issues/2026-06-07-collect-benchmark-step-3-7-pro.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-07
+agent: collect-benchmark
+severity: minor
+target: llm/step-3-7-pro
+---
+
+## 상황
+`step-3-7-pro` 의 소스 URL (https://www.stepfun.com/news) 에 접근할 수 없음 (404 Error).
+
+## 시도한 것
+해당 URL 접속 시도.
+
+## 요청
+새로운 공식 URL 및 벤치마크 수치 확인 필요.

--- a/src/data/journal/2026-06-07-collect-benchmark.md
+++ b/src/data/journal/2026-06-07-collect-benchmark.md
@@ -1,0 +1,31 @@
+---
+date: 2026-06-07
+agent: collect-benchmark
+status: completed
+summary: "GLM-5 벤치마크 점수 등록 (SWE-bench Verified, Terminal Bench 2.0)"
+---
+
+## Todo
+- 신규 모델의 벤치마크 점수 등록
+## 조사 내역
+- 16:50 `collect-llm` 저널 (2026-06-06) 확인. 추가된 모델: `solar-pro-2`, `solar-pro-2-preview`, `gemini-omni-pro`, `glm-4-7-pro`, `step-3-7-pro`.
+- 16:55 해당 모델들의 출처 URL 스크래핑을 통한 벤치마크 점수 조사.
+  - `solar-pro-2` / `preview` (https://www.upstage.ai/blog/en/solar-pro-2-launch 등): 구체적 수치 없는 텍스트만 존재. 점수 확인 실패.
+  - `gemini-omni` (https://deepmind.google/models/gemini-omni/): 수치 없음.
+  - `glm-4-7-pro` (https://www.zhipuai.cn/news): `GLM-5` 에 대한 점수가 확인됨 (`SWE-bench Verified: 77.8`, `Terminal Bench 2.0: 56.2`).
+  - `step-3-7-pro`: 접근 불가.
+
+## 수행한 작업
+- [x] GLM-5 점수 등록
+  - SWE-bench Verified: 77.8 ← https://www.zhipuai.cn/news
+  - Terminal Bench 2.0: 56.2 ← https://www.zhipuai.cn/news
+
+## 판단 / 고민
+- 다른 신규 모델들의 출처 웹사이트에서는 명확한 점수 수치가 텍스트로 존재하지 않음 (이미지거나 구체적인 숫자 누락). Groundedness Rule에 따라 불명확한 점수는 저장하지 않음.
+- 출처가 불분명하거나 없는 모델에 대해서는 이슈 티켓을 발행하여 추후 갱신 유도.
+
+## 이슈 제기
+- issues/2026-06-07-collect-benchmark-solar-pro-2.md
+- issues/2026-06-07-collect-benchmark-gemini-omni-pro.md
+- issues/2026-06-07-collect-benchmark-glm-4-7-pro.md
+- issues/2026-06-07-collect-benchmark-step-3-7-pro.md


### PR DESCRIPTION
I have completed the `collect-benchmark` session for `2026-06-07`.

1. Read the `collect-llm` journal for new models.
2. Explored their sources for explicit benchmark scores (MMLU, HumanEval, SWE-bench, etc).
3. **No scores/dead links:** `solar-pro-2`, `gemini-omni-pro`, `glm-4-7-pro`, `step-3-7-pro` lack explicit benchmark scores in text or are dead links. Created corresponding issue tickets.
4. **Found scores:** Extracted `SWE-bench Verified` (77.8) and `Terminal Bench 2.0` (56.2) for `GLM-5` from Zhipu AI news and properly added them via `benchmark.ts`.
5. Created the journal entry indicating `completed` status.

---
*PR created automatically by Jules for task [3032206369656425947](https://jules.google.com/task/3032206369656425947) started by @GGJJack*