### PR TITLE
docs: generate daily report for 2026-06-07 and update journal status

### DIFF
--- a/src/data/journal/2026-06-08-journal.md
+++ b/src/data/journal/2026-06-08-journal.md
@@ -1,0 +1,8 @@
+---
+title: "2026-06-08 journal Journal"
+status: completed
+updated: 2026-06-08
+---
+
+## 수행한 작업
+- [x] `src/data/updates/2026-06-07-daily.md` 작성 (2026-06-07 저널 기준)

--- a/src/data/updates/2026-06-07-daily.md
+++ b/src/data/updates/2026-06-07-daily.md
@@ -1,0 +1,38 @@
+---
+date: 2026-06-07
+type: note
+title: 데일리 리포트 · 2026-06-07
+summary: 신규 모델 5종 등록, GLM-5 등 벤치마크 점수 보강, 생명과학 벤치마크 페이지 작성 및 컨텍스트 보강
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: claude-3-7-sonnet ← https://www.anthropic.com/news/claude-3-7-sonnet
+- 신규: claude-3-7-haiku ← https://www.anthropic.com/news/claude-3-7-sonnet
+- 신규: llama-3-3-70b-instruct ← https://ai.meta.com/blog/llama-3-3/
+- 신규: phi-4 ← https://azure.microsoft.com/en-us/blog/introducing-phi-4-microsofts-newest-small-language-model-now-available-on-azure-ai-models-as-a-service/
+- 신규: phi-4-multimodal-instruct ← https://huggingface.co/microsoft/phi-4-multimodal-instruct
+- 보강: gemini-3-5-pro · parameterSize ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- 보강: qwen-3.5-2b · parameterSize ← https://qwen.ai/research
+- 보강: claude-opus-4-8 · parameterSize ← https://www.anthropic.com/news/claude-opus-4-8
+- 보강: step-3-7-pro · parameterSize ← https://www.stepfun.com/news
+
+### 벤치마크 (collect-benchmark)
+- 신규: GLM-5 점수 등록 (SWE-bench Verified: 77.8, Terminal Bench 2.0: 56.2) ← https://www.zhipuai.cn/news
+
+## 상세 페이지 작성 (profile)
+- src/content/benchmarks/genebench.md 작성 및 openai 기관 연결 ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- src/content/benchmarks/medchembench.md 기관 정보 추가 및 날짜 업데이트
+- src/content/benchmarks/lifescibench.md 날짜 업데이트
+
+## 이슈 처리 (reinforce)
+- HyperCLOVA X (HCX-007) context window 보강 (128K) ← https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3
+- Yi-Large context window 보강 (33K) ← https://openrouter.ai/models/01-ai/yi-large/pricing
+- Qwen3 (235B, 32B) 주요 벤치마크 점수 보강 (ArenaHard, Codeforces, AIME'25) ← https://qwenlm.github.io/blog/qwen3/
+
+## 미해결 이슈
+- issues/2026-06-07-collect-benchmark-solar-pro-2.md
+- issues/2026-06-07-collect-benchmark-gemini-omni-pro.md
+- issues/2026-06-07-collect-benchmark-glm-4-7-pro.md
+- issues/2026-06-07-collect-benchmark-step-3-7-pro.md


### PR DESCRIPTION
Generates the daily report for 2026-06-07 based on the previous day's agent logs and marks the 2026-06-08 journal entry as completed.

---
*PR created automatically by Jules for task [15925361350277526044](https://jules.google.com/task/15925361350277526044) started by @GGJJack*