### PR TITLE
chore(benchmark): log missing benchmark scores and create issues

### DIFF
--- a/src/data/issues/2026-06-08-collect-benchmark-claude.md
+++ b/src/data/issues/2026-06-08-collect-benchmark-claude.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-08
+agent: collect-benchmark
+severity: minor
+target: llm/claude-3-7-sonnet
+---
+
+## 상황
+Claude 3.7 Sonnet의 공식 출시 글(https://www.anthropic.com/news/claude-3-7-sonnet)에서 벤치마크 점수 데이터가 텍스트가 아닌 이미지(바 차트 및 표)로 제공되어 수치 데이터의 신뢰성 있는 파싱이 불가능합니다.
+
+## 시도한 것
+웹 페치로 페이지 소스를 긁어 `swe-bench-verified`, `tau-bench` 등의 텍스트를 탐색했으나, "state-of-the-art" 같은 설명만 있고 정확한 숫자는 이미지(예: `787e59d548c230afd7efaed1bda1fb7f7ca207b8-1920x1114.png`, `08bba4487fb5ac1ba52540ee656d7e4da10ca1be-1920x1145.png`) 안에만 존재합니다. 규칙상 이미지의 수동 타이핑/환각 등록이 금지되어 있어 점수 매칭을 스킵했습니다.
+
+## 요청
+텍스트 형태의 신뢰할 수 있는 다른 공식 소스를 탐색하여 점수를 업데이트하거나, 사람이 검토 후 추가하도록 요청합니다.

--- a/src/data/issues/2026-06-08-collect-benchmark-gemini.md
+++ b/src/data/issues/2026-06-08-collect-benchmark-gemini.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-08
+agent: collect-benchmark
+severity: minor
+target: llm/gemini-3-5-flash
+---
+
+## 상황
+Gemini 3.5 Flash의 관련 공식 블로그 글(https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/)에서 벤치마크 점수가 텍스트가 아닌 이미지(예: `gemini-3-5__benchmarks__light.gif`) 형태로 제공되어 텍스트 파싱을 통한 정확한 수치 추출이 불가능합니다.
+
+## 시도한 것
+해당 블로그 글을 텍스트로 가져와 확인했으나 일부 벤치마크 이름만 언급될 뿐 전체 상세 점수표는 이미지 포맷으로 존재하여, 환각 등록을 방지하기 위해 등록을 스킵했습니다.
+
+## 요청
+텍스트 기반의 점수 표를 확인할 수 있는 백서/기술 문서 등의 대체 출처 탐색을 요청합니다.

--- a/src/data/issues/2026-06-08-collect-benchmark-llama.md
+++ b/src/data/issues/2026-06-08-collect-benchmark-llama.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-08
+agent: collect-benchmark
+severity: minor
+target: llm/llama-3-3-70b-instruct
+---
+
+## 상황
+llama-3-3-70b-instruct의 공식 블로그 링크(https://ai.meta.com/blog/llama-3-3/)에서 텍스트 기반의 벤치마크 점수 표를 찾을 수 없거나 JS로 막혀 있어 수집에 실패했습니다.
+
+## 시도한 것
+curl 명령어를 통해 페이지 소스를 가져오려 했으나 브라우저 버전 오류 메시지 등으로 인해 본문 데이터 접근이 원활하지 않았습니다.
+
+## 요청
+이 모델의 벤치마크 점수 수집을 위한 다른 공식 텍스트 출처(예: arXiv 백서 또는 Hugging Face 모델 카드 등) 확인을 요청합니다.

--- a/src/data/issues/2026-06-08-collect-benchmark-phi-4.md
+++ b/src/data/issues/2026-06-08-collect-benchmark-phi-4.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-08
+agent: collect-benchmark
+severity: minor
+target: llm/phi-4
+---
+
+## 상황
+Phi-4 및 Phi-4-multimodal-instruct의 공식 블로그 페이지(https://azure.microsoft.com/en-us/blog/introducing-phi-4-microsofts-newest-small-language-model-now-available-on-azure-ai-models-as-a-service/ 및 Hugging Face 모델 카드)에서 점수 데이터를 수집하려고 했으나, 파싱 가능한 텍스트 포맷의 벤치마크 점수(MMLU, HumanEval 등)가 명확하게 존재하지 않았습니다.
+
+## 시도한 것
+웹 페치로 페이지 소스를 긁어 확인했으나 수치가 포함된 텍스트 표를 찾지 못하여, 임의 기입을 피하기 위해 수집을 보류했습니다.
+
+## 요청
+텍스트 형태로 점수 정보가 명시된 대체 공식 문서 확인을 요청합니다.

--- a/src/data/journal/2026-06-08-collect-benchmark.md
+++ b/src/data/journal/2026-06-08-collect-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-08
+agent: collect-benchmark
+status: completed
+summary: "신규 모델 점수 매칭 시도 및 이미지/스크립트 등 출처 미확인 이슈 티켓 생성"
+---
+
+## 조사 내역
+- 16:33  Claude 3.7 Sonnet 점수 확인 시도 (이미지로 제공되어 수치 파싱 불가)  ← https://www.anthropic.com/news/claude-3-7-sonnet
+- 16:34  Gemini 3.5 Flash 점수 확인 시도 (이미지로 제공되어 수치 파싱 불가)  ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- 16:45  Llama 3.3 70B 점수 확인 시도 (JS 렌더링 등으로 인해 파싱 실패)  ← https://ai.meta.com/blog/llama-3-3/
+- 16:45  Phi-4 점수 확인 시도 (명확한 수치 부재)  ← https://azure.microsoft.com/en-us/blog/introducing-phi-4-microsofts-newest-small-language-model-now-available-on-azure-ai-models-as-a-service/
+
+## 수행한 작업
+- [x] 출처 URL 확인 불가/이미지 등으로 인한 이슈 티켓 4건 생성
+
+## 이슈 제기
+- issues/2026-06-08-collect-benchmark-claude.md
+- issues/2026-06-08-collect-benchmark-gemini.md
+- issues/2026-06-08-collect-benchmark-llama.md
+- issues/2026-06-08-collect-benchmark-phi-4.md


### PR DESCRIPTION
- Claude 3.7 Sonnet: Scores presented in images/charts, cannot parse raw numbers.
- Gemini 3.5 Flash: Scores presented in an image (.gif), cannot parse raw numbers.
- Llama 3.3: Website inaccessible due to browser verification.
- Phi-4: Explicit score tables not found in the source text.
- Created corresponding issue tickets instead of hallucinating data.
- Added daily journal entry for `collect-benchmark`.

---
*PR created automatically by Jules for task [6313428812046484554](https://jules.google.com/task/6313428812046484554) started by @GGJJack*