### PR TITLE
feat: add GeneBench and LifeSciBench profiles, report BixBench issue

### DIFF
--- a/src/content/benchmarks/genebench.md
+++ b/src/content/benchmarks/genebench.md
@@ -1,0 +1,19 @@
+---
+benchmarkId: genebench
+domain: llm
+status: published
+updated: 2026-06-08
+sources:
+  - https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+organization: openai
+highlights:
+  - "유전학 및 정량 생물학 분야의 장기적, 엔드투엔드 분석 능력을 평가"
+---
+
+# GeneBench
+
+## 개요
+유전학 및 정량 생물학 분야의 장기적, 엔드투엔드 분석 능력을 평가하는 에이전틱 벤치마크.
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/content/benchmarks/lifescibench.md
+++ b/src/content/benchmarks/lifescibench.md
@@ -1,19 +1,19 @@
 ---
 benchmarkId: lifescibench
 domain: llm
-status: draft
-updated: 2026-06-07
+status: published
+updated: 2026-06-08
 sources:
   - https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
 organization: openai
 highlights:
-  - "Foundational aspects in life sciences research: evidence handling, analysis, design and optimization, scientific reasoning, validation and operations, and translation and communication."
+  - "생명과학 연구 중심의 포괄적 벤치마크"
 ---
 
 # LifeSciBench
 
 ## 개요
-Foundational aspects in life sciences research: evidence handling, analysis, design and optimization, scientific reasoning, validation and operations, and translation and communication.
+증거 처리, 분석, 설계 및 최적화, 과학적 추론, 검증 및 운영, 번역 및 커뮤니케이션 등 6가지 생명과학 연구 워크플로우를 평가하는 벤치마크.
 
 ## 평가 방법
 평가 단위는 %를 사용합니다.

--- a/src/data/issues/2026-06-08-profile-benchmark-bixbench.md
+++ b/src/data/issues/2026-06-08-profile-benchmark-bixbench.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-08
+agent: profile-benchmark
+severity: blocker
+target: llm/bixbench
+---
+
+## 상황
+BixBench의 공식 출처 URL `https://openai.com/index/introducing-gpt-rosalind/` 에 접근할 수 없어(Fetch 실패), 내용을 확인할 수 없음.
+
+## 시도한 것
+해당 URL을 `view_text_website`와 `curl`을 통해 조회하려 했으나 실패하거나 관련 정보가 조회되지 않음.
+
+## 요청
+BixBench의 유효한 출처 URL을 찾아 업데이트하고 상세 페이지 작성을 재시도 바람.

--- a/src/data/journal/2026-06-08-profile-benchmark.md
+++ b/src/data/journal/2026-06-08-profile-benchmark.md
@@ -1,0 +1,22 @@
+---
+title: "profile-benchmark: GeneBench, LifeSciBench 프로필 작성 및 BixBench 이슈 생성"
+status: completed
+updated: 2026-06-08
+---
+
+## Todo
+- [x] 누락된 llm 도메인 벤치마크 상세 페이지 작성 (GeneBench, LifeSciBench)
+- [x] 정보 접근 불가 BixBench 이슈 생성
+
+## 조사 내역
+- 02:30  GeneBench 세부 내용 확인  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- 02:30  LifeSciBench 세부 내용 확인  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- 02:32  BixBench 세부 내용 확인 시도 (페이지 접근 불가하여 JSON 정의에 의존)  ← https://openai.com/index/introducing-gpt-rosalind/
+
+## 수행한 작업
+- [x] `src/content/benchmarks/genebench.md` 작성 (published)  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- [x] `src/content/benchmarks/lifescibench.md` 작성 (published)  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- [x] `src/data/issues/2026-06-08-profile-benchmark-bixbench.md` 이슈 생성  ← https://openai.com/index/introducing-gpt-rosalind/
+
+## 이슈 제기
+- issues/2026-06-08-profile-benchmark-bixbench.md


### PR DESCRIPTION
Added markdown profile pages for `GeneBench` and `LifeSciBench` based on verified information from the OpenAI update post.
Also created an issue ticket for `BixBench` as its official URL could not be fetched for details.
Updated the journal for the session accordingly.

---
*PR created automatically by Jules for task [3334814977330608163](https://jules.google.com/task/3334814977330608163) started by @GGJJack*