### PR TITLE
collect-llm 2026-06-08: Anthropic, Sakana AI, and metadata reinforcement

### DIFF
--- a/src/data/journal/2026-06-08-collect-llm.md
+++ b/src/data/journal/2026-06-08-collect-llm.md
@@ -1,0 +1,30 @@
+---
+status: completed
+---
+
+# 2026-06-08 collect-llm
+
+## 시작 상태
+- LLM 도메인 메타데이터 수집 및 보강 세션 시작.
+- 주요 타겟: Anthropic, Mistral AI, Sakana AI, Inception Labs, Upstage 등의 신규 모델 및 누락 정보.
+
+## 변경 사항
+### 신규 등록
+- mythos-preview (Anthropic): Project Glasswing을 통해 발표된 보안 특화 frontier 모델. ($25/$125)
+- claude-opus-4-6 (Anthropic): Opus 4.5의 후속작으로 1M 컨텍스트 지원. ($5/$25)
+- llama-3.1-namazu-405b (Sakana AI): Llama 3.1 405B 기반 일본어 튜닝 모델.
+- namazu-gpt-oss-120b (Sakana AI): GPT-OSS 120B 기반 일본어 튜닝 모델.
+
+### 기존 모델 보강
+- mercury-2 (Inception Labs): 출시일(2026-02-24), 가격($0.25/$0.75), 컨텍스트 윈도우(128,000) 보강.
+- solar-pro-2 (Upstage): 파라미터 크기(31B) 보강.
+- claude-opus-4-8 (Anthropic): 공식 링크 보강.
+
+## 교차 도메인 발견
+- grok-imagine-video-1.5-preview (image-gen/video): xAI의 이미지-비디오 모델. (2026-06-03)
+- voxtral-tts (tts): Mistral AI의 텍스트-음성 모델.
+- veo (image-gen/video): Google의 비디오 생성 모델.
+- imagen (image-gen): Google의 이미지 생성 모델.
+- lyria (tts/music): Google의 음악 생성 모델.
+- nano-banana (image-gen): Google의 이미지 생성 모델.
+- gemini-audio (stt/audio): Google의 오디오 처리 모델.

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -2546,15 +2546,18 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": null,
-      "pricing": null,
+      "contextWindow": 128000,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.75
+      },
       "links": {
-        "official": "https://www.inceptionlabs.ai/mercury-2"
+        "official": "https://www.inceptionlabs.ai/blog/introducing-mercury-2"
       },
       "id": "mercury-2",
       "name": "Mercury 2",
       "provider": "Inception Labs",
-      "releaseDate": "2026-05-28",
+      "releaseDate": "2026-02-24",
       "license": "Proprietary"
     },
     {
@@ -2600,7 +2603,7 @@
       "license": "Proprietary"
     },
     {
-      "parameterSize": null,
+      "parameterSize": "31B",
       "contextWindow": 128000,
       "pricing": {
         "input": 0.25,
@@ -2749,6 +2752,64 @@
       "provider": "Microsoft",
       "releaseDate": "2025-02-19",
       "license": "MIT"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": {
+        "input": 25,
+        "output": 125
+      },
+      "links": {
+        "official": "https://www.anthropic.com/glasswing"
+      },
+      "id": "mythos-preview",
+      "name": "Claude Mythos Preview",
+      "provider": "Anthropic",
+      "releaseDate": "2026-05-22",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": 1000000,
+      "pricing": {
+        "input": 5,
+        "output": 25
+      },
+      "links": {
+        "official": "https://www.anthropic.com/news/claude-opus-4-6"
+      },
+      "id": "claude-opus-4-6",
+      "name": "Claude Opus 4.6",
+      "provider": "Anthropic",
+      "releaseDate": "2026-02-05",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://sakana.ai/namazu-alpha/"
+      },
+      "id": "llama-3-1-namazu-405b",
+      "name": "Llama-3.1-Namazu-405B",
+      "provider": "Sakana AI",
+      "releaseDate": "2026-03-24",
+      "license": "Llama 3.1 License"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": null,
+      "links": {
+        "official": "https://sakana.ai/namazu-alpha/"
+      },
+      "id": "namazu-gpt-oss-120b",
+      "name": "Namazu-gpt-oss-120B",
+      "provider": "Sakana AI",
+      "releaseDate": "2026-03-24",
+      "license": "Apache-2.0"
     }
   ]
 }


### PR DESCRIPTION
This session focused on collecting and reinforcing metadata for Large Language Models from Anthropic, Sakana AI, Inception Labs, and Upstage.

Key changes:
1. **New Registrations**:
   - `mythos-preview` (Anthropic): Security-focused frontier model ($25/$125).
   - `claude-opus-4-6` (Anthropic): Predecessor to 4.7, first with 1M context ($5/$25).
   - `llama-3.1-namazu-405b` & `namazu-gpt-oss-120b` (Sakana AI): Japanese-tuned frontier models.
2. **Metadata Reinforcement**:
   - `mercury-2` (Inception Labs): Verified release date (2026-02-24), 128k context, and pricing ($0.25/$0.75).
   - `solar-pro-2` (Upstage): Verified parameter size as 31B.
   - `claude-opus-4-8` (Anthropic): Added missing official news link.
3. **Cross-Domain Discoveries**: Documented 7 models (image-gen, video, tts, audio) in the journal for specialists.

All changes verified via `manage-model` script and project-wide `build`.

Fixes #433

---
*PR created automatically by Jules for task [2951202927775541446](https://jules.google.com/task/2951202927775541446) started by @GGJJack*