### PR TITLE
feat(journal): generate daily report for 2026-06-08

### DIFF
--- a/src/data/journal/2026-06-09-journal.md
+++ b/src/data/journal/2026-06-09-journal.md
@@ -1,0 +1,9 @@
+---
+title: "journal: 데일리 리포트 생성 완료"
+status: completed
+updated: 2026-06-09
+---
+
+## 수행한 작업
+- [x] 2026-06-08 일자 collect-*, profile-*, reinforce 저널 통합 스크립트 작성 및 실행
+- [x] `src/data/updates/2026-06-08-daily.md` 데일리 리포트 발행 완료

--- a/src/data/updates/2026-06-08-daily.md
+++ b/src/data/updates/2026-06-08-daily.md
@@ -1,0 +1,67 @@
+---
+date: 2026-06-08
+type: note
+title: 데일리 리포트 · 2026-06-08
+summary: 전일 수행된 총 43건의 작업 및 5건의 이슈가 집계되었습니다.
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- LLM 도메인 메타데이터 수집 및 보강 세션 시작.
+- 주요 타겟: Anthropic, Mistral AI, Sakana AI, Inception Labs, Upstage 등의 신규 모델 및 누락 정보.
+- mythos-preview (Anthropic): Project Glasswing을 통해 발표된 보안 특화 frontier 모델. ($25/$125)
+- claude-opus-4-6 (Anthropic): Opus 4.5의 후속작으로 1M 컨텍스트 지원. ($5/$25)
+- llama-3.1-namazu-405b (Sakana AI): Llama 3.1 405B 기반 일본어 튜닝 모델.
+- namazu-gpt-oss-120b (Sakana AI): GPT-OSS 120B 기반 일본어 튜닝 모델.
+- mercury-2 (Inception Labs): 출시일(2026-02-24), 가격($0.25/$0.75), 컨텍스트 윈도우(128,000) 보강.
+- solar-pro-2 (Upstage): 파라미터 크기(31B) 보강.
+- claude-opus-4-8 (Anthropic): 공식 링크 보강.
+- grok-imagine-video-1.5-preview (image-gen/video): xAI의 이미지-비디오 모델. (2026-06-03)
+- voxtral-tts (tts): Mistral AI의 텍스트-음성 모델.
+- veo (image-gen/video): Google의 비디오 생성 모델.
+- imagen (image-gen): Google의 이미지 생성 모델.
+- lyria (tts/music): Google의 음악 생성 모델.
+- nano-banana (image-gen): Google의 이미지 생성 모델.
+- gemini-audio (stt/audio): Google의 오디오 처리 모델.
+
+### 벤치마크 (collect-benchmark)
+- 16:33  Claude 3.7 Sonnet 점수 확인 시도 (이미지로 제공되어 수치 파싱 불가)  ← https://www.anthropic.com/news/claude-3-7-sonnet
+- 16:34  Gemini 3.5 Flash 점수 확인 시도 (이미지로 제공되어 수치 파싱 불가)  ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
+- 16:45  Llama 3.3 70B 점수 확인 시도 (JS 렌더링 등으로 인해 파싱 실패)  ← https://ai.meta.com/blog/llama-3-3/
+- 16:45  Phi-4 점수 확인 시도 (명확한 수치 부재)  ← https://azure.microsoft.com/en-us/blog/introducing-phi-4-microsofts-newest-small-language-model-now-available-on-azure-ai-models-as-a-service/
+- [x] 출처 URL 확인 불가/이미지 등으로 인한 이슈 티켓 4건 생성
+
+## 상세 페이지 작성 (profile)
+- [x] 누락된 llm 도메인 벤치마크 상세 페이지 작성 (GeneBench, LifeSciBench)
+- [x] 정보 접근 불가 BixBench 이슈 생성
+- 02:30  GeneBench 세부 내용 확인  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- 02:30  LifeSciBench 세부 내용 확인  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- 02:32  BixBench 세부 내용 확인 시도 (페이지 접근 불가하여 JSON 정의에 의존)  ← https://openai.com/index/introducing-gpt-rosalind/
+- [x] `src/content/benchmarks/genebench.md` 작성 (published)  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- [x] `src/content/benchmarks/lifescibench.md` 작성 (published)  ← https://openai.com/index/introducing-new-capabilities-to-gpt-rosalind/
+- [x] `src/data/issues/2026-06-08-profile-benchmark-bixbench.md` 이슈 생성  ← https://openai.com/index/introducing-gpt-rosalind/
+- `src/content/models/` 에 등록되지 않은 주요 모델 상세 페이지 작성.
+- 우선순위: 최근 등록된 메이저 모델 (Claude 3.7 Sonnet, Llama 3.3 70B Instruct 등)
+- [2026-06-08] 저널 생성 및 대상 선정.
+- 대상 1: `claude-3-7-sonnet`
+- 대상 2: `llama-3-3-70b-instruct`
+- [2026-06-08] 프로파일 작성 및 검증 완료.
+- `src/content/models/claude-3-7-sonnet.md` (published)
+- `src/content/models/llama-3-3-70b-instruct.md` (published)
+- `bun run build`를 통한 스키마 검증 완료.
+- [x] `claude-3-7-sonnet` 프로파일 작성
+- [x] `llama-3-3-70b-instruct` 프로파일 작성
+- [x] 스키마 검증 (`bun run build`)
+- `src/content/models/claude-3-7-sonnet.md`
+- `src/content/models/llama-3-3-70b-instruct.md`
+
+## 이슈 처리 (reinforce)
+- 없음
+
+## 미해결 이슈
+- issues/2026-06-08-collect-benchmark-claude.md
+- issues/2026-06-08-collect-benchmark-gemini.md
+- issues/2026-06-08-collect-benchmark-llama.md
+- issues/2026-06-08-collect-benchmark-phi-4.md
+- issues/2026-06-08-profile-benchmark-bixbench.md


### PR DESCRIPTION
This PR implements the requested `journal` task. 

It triggers dynamically via a Node.js script that parses the journal files matching yesterday's date (`2026-06-08`), effectively aggregating all activity (additions, profiles, unhandled issues) and extracting the required URLs and metrics. The output is a cleanly structured daily report saved as `src/data/updates/2026-06-08-daily.md`. In addition, it concludes the task by creating today's (`2026-06-09`) journal log marking the operation as `completed`, as required. 

Build/validation verified successful.

---
*PR created automatically by Jules for task [15856530722633613615](https://jules.google.com/task/15856530722633613615) started by @GGJJack*