### PR TITLE
Collect LLM - 2026-06-09: Claude 5 series and metadata reinforcement

### DIFF
--- a/src/data/journal/2026-06-09-collect-llm.md
+++ b/src/data/journal/2026-06-09-collect-llm.md
@@ -1,0 +1,31 @@
+---
+date: 2026-06-09
+agent: collect-llm
+status: completed
+summary: "Claude Fable 5, Claude Mythos 5 신규 등록 및 Claude Mythos Preview, Mistral Small 4 등 기존 모델 메타데이터 보강"
+---
+
+## Todo
+- [x] Anthropic 신규 모델(Claude Fable 5, Mythos 5) 발견 및 등록
+- [x] Claude Mythos Preview 출시일 및 가격 정보 보강
+- [x] Mistral Small 4 라이선스 정보 보강
+- [x] Mistral Medium 3.5 가격 정보 보강
+
+## 조사 내역
+- 10:15  Anthropic Claude Fable 5 및 Mythos 5 공식 출시 확인 ($10/$50) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 10:18  Claude Mythos Preview 정식 출시일(2026-04-07) 및 가격($25/$125) 확인 ← https://www.anthropic.com/glasswing
+- 10:20  Mistral Small 4 라이선스(Apache-2.0) 확인 ← https://mistral.ai/news/mistral-small-4/
+- 10:21  Mistral Medium 3.5 가격($1.5/$7.5) 확인 ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/
+
+## 수행한 작업
+- [x] Claude Fable 5 (claude-fable-5) 등록
+- [x] Claude Mythos 5 (claude-mythos-5) 등록
+- [x] Claude Mythos Preview (claude-mythos-preview) 정보 갱신 (releaseDate: 2026-04-07, pricing: 25/125) 및 중복 id(mythos-preview) 제거
+- [x] Mistral Small 4 (mistral-small-4) 정보 갱신 (license: Apache-2.0)
+- [x] Mistral Medium 3.5 (mistral-medium-3-5) 정보 갱신 (pricing: 1.5/7.5)
+
+## 판단 / 고민
+- Apple Intelligence 신규 모델(AFM-3, AFM-4 등)은 WWDC 2026 뉴스룸에서 구체적인 스펙이나 개별 모델명이 식별되지 않아 이번 회차에서는 등록 보류.
+
+## 이슈 제기
+- (없음)

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -204,7 +204,10 @@
     {
       "parameterSize": null,
       "contextWindow": null,
-      "pricing": null,
+      "pricing": {
+        "input": 25,
+        "output": 125
+      },
       "links": {
         "official": "https://www.anthropic.com/glasswing"
       },
@@ -321,7 +324,7 @@
       "name": "Mistral Small 4",
       "provider": "Mistral AI",
       "releaseDate": "2026-03-16",
-      "license": "Modified MIT"
+      "license": "Apache-2.0"
     },
     {
       "parameterSize": null,
@@ -2755,22 +2758,6 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": null,
-      "pricing": {
-        "input": 25,
-        "output": 125
-      },
-      "links": {
-        "official": "https://www.anthropic.com/glasswing"
-      },
-      "id": "mythos-preview",
-      "name": "Claude Mythos Preview",
-      "provider": "Anthropic",
-      "releaseDate": "2026-05-22",
-      "license": "Proprietary"
-    },
-    {
-      "parameterSize": null,
       "contextWindow": 1000000,
       "pricing": {
         "input": 5,
@@ -2810,6 +2797,38 @@
       "provider": "Sakana AI",
       "releaseDate": "2026-03-24",
       "license": "Apache-2.0"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": {
+        "input": 10,
+        "output": 50
+      },
+      "links": {
+        "official": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "id": "claude-fable-5",
+      "name": "Claude Fable 5",
+      "provider": "Anthropic",
+      "releaseDate": "2026-06-09",
+      "license": "Proprietary"
+    },
+    {
+      "parameterSize": null,
+      "contextWindow": null,
+      "pricing": {
+        "input": 10,
+        "output": 50
+      },
+      "links": {
+        "official": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "id": "claude-mythos-5",
+      "name": "Claude Mythos 5",
+      "provider": "Anthropic",
+      "releaseDate": "2026-06-09",
+      "license": "Proprietary"
     }
   ]
 }


### PR DESCRIPTION
Registered two new Anthropic models (Claude Fable 5 and Claude Mythos 5) released on June 9, 2026, with confirmed $10/$50 pricing. Reinforced metadata for existing models: corrected Claude Mythos Preview release date to 2026-04-07 and added post-preview pricing ($25/$125); updated Mistral Small 4 license to Apache-2.0; and confirmed Mistral Medium 3.5 pricing ($1.5/$7.5). Resolved a duplicate entry for mythos-preview in the registry. All changes verified via local build and registry inspection.

Fixes #440

---
*PR created automatically by Jules for task [2780158145249381389](https://jules.google.com/task/2780158145249381389) started by @GGJJack*