### PR TITLE
feat(benchmark): collect benchmark scores for new Anthropic and Mistral models

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -697,13 +697,13 @@
         "value": 77.6,
         "date": "2026-05-22",
         "source": "official",
-        "sourceUrl": "https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/"
+        "url": "https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/"
       },
       "tau-bench-telecom": {
         "value": 91.4,
         "date": "2026-05-22",
         "source": "official",
-        "sourceUrl": "https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/"
+        "url": "https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/"
       }
     },
     "mistral-large-3": {
@@ -1923,10 +1923,40 @@
         "sourceUrl": "https://www.anthropic.com/news/claude-opus-4-8"
       },
       "legal-agent-bench": {
-        "value": 10,
-        "date": "2026-05-28",
+        "value": 10.4,
+        "date": "2026-06-09",
         "source": "official",
-        "sourceUrl": "https://www.anthropic.com/news/claude-opus-4-8"
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "swe-bench-pro": {
+        "value": 69.2,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "gdpval-aa": {
+        "value": 1890,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "osworld-verified": {
+        "value": 83.4,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "hle": {
+        "value": 57.9,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "terminal-bench-2-1": {
+        "value": 82.7,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
       }
     },
     "hcx-007": {
@@ -2109,6 +2139,116 @@
         "date": "2024-03-04",
         "source": "community",
         "sourceUrl": "https://huggingface.co/yanolja/EEVE-Korean-Instruct-10.8B-v1.0"
+      }
+    },
+    "claude-fable-5": {
+      "swe-bench-pro": {
+        "value": 80.3,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "gdpval-aa": {
+        "value": 1932,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "osworld-verified": {
+        "value": 85,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "legal-agent-bench": {
+        "value": 13.3,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "hle": {
+        "value": 64.5,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "terminal-bench-2-1": {
+        "value": 88,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      }
+    },
+    "claude-mythos-5": {
+      "swe-bench-pro": {
+        "value": 80.3,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "gdpval-aa": {
+        "value": 1932,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "osworld-verified": {
+        "value": 85,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "legal-agent-bench": {
+        "value": 13.3,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "hle": {
+        "value": 64.5,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "terminal-bench-2-1": {
+        "value": 88,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      }
+    },
+    "claude-mythos-preview": {
+      "swe-bench-pro": {
+        "value": 77.8,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "osworld-verified": {
+        "value": 85.4,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      },
+      "hle": {
+        "value": 64.7,
+        "date": "2026-06-09",
+        "source": "official",
+        "url": "https://www.anthropic.com/news/claude-fable-5-mythos-5"
+      }
+    },
+    "mistral-small-4": {
+      "aime-2025": {
+        "value": 83.8,
+        "date": "2026-03-16",
+        "source": "official",
+        "url": "https://mistral.ai/news/mistral-small-4/"
+      },
+      "livecodebench-v6": {
+        "value": 63.6,
+        "date": "2026-03-16",
+        "source": "official",
+        "url": "https://mistral.ai/news/mistral-small-4/"
       }
     }
   }

--- a/src/data/issues/2026-06-10-collect-benchmark-automationbench.md
+++ b/src/data/issues/2026-06-10-collect-benchmark-automationbench.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-10
+agent: collect-benchmark
+severity: minor
+target: llm/automationbench
+---
+
+## 상황  https://www.anthropic.com/news/claude-fable-5-mythos-5 에 있는 벤치마크 표
+AutomationBench (Tool use) 점수가 기재되어 있으나 시스템에 해당 벤치마크가 없습니다.
+
+## 시도한 것
+벤치마크 목록 검색
+
+## 요청  reinforce가 할 구체 작업
+AutomationBench 벤치마크를 추가해 주세요.

--- a/src/data/issues/2026-06-10-collect-benchmark-biomysterybench.md
+++ b/src/data/issues/2026-06-10-collect-benchmark-biomysterybench.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-10
+agent: collect-benchmark
+severity: minor
+target: llm/biomysterybench
+---
+
+## 상황  https://www.anthropic.com/news/claude-fable-5-mythos-5 에 있는 벤치마크 표
+BioMysteryBench (Biology) 점수가 기재되어 있으나 시스템에 해당 벤치마크가 없습니다.
+
+## 시도한 것
+벤치마크 목록 검색
+
+## 요청  reinforce가 할 구체 작업
+BioMysteryBench 벤치마크를 추가해 주세요.

--- a/src/data/issues/2026-06-10-collect-benchmark-blueprint-bench-2.md
+++ b/src/data/issues/2026-06-10-collect-benchmark-blueprint-bench-2.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-10
+agent: collect-benchmark
+severity: minor
+target: llm/blueprint-bench-2
+---
+
+## 상황  https://www.anthropic.com/news/claude-fable-5-mythos-5 에 있는 벤치마크 표
+Blueprint-Bench 2 (Spatial reasoning) 점수가 기재되어 있으나 시스템에 해당 벤치마크가 없습니다.
+
+## 시도한 것
+벤치마크 목록 검색
+
+## 요청  reinforce가 할 구체 작업
+Blueprint-Bench 2 벤치마크를 추가해 주세요.

--- a/src/data/issues/2026-06-10-collect-benchmark-exploitbench.md
+++ b/src/data/issues/2026-06-10-collect-benchmark-exploitbench.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-10
+agent: collect-benchmark
+severity: minor
+target: llm/exploitbench
+---
+
+## 상황  https://www.anthropic.com/news/claude-fable-5-mythos-5 에 있는 벤치마크 표
+ExploitBench (Cap%) (Cybersecurity) 점수가 기재되어 있으나 시스템에 해당 벤치마크가 없습니다.
+
+## 시도한 것
+벤치마크 목록 검색
+
+## 요청  reinforce가 할 구체 작업
+ExploitBench 벤치마크를 추가해 주세요.

--- a/src/data/issues/2026-06-10-collect-benchmark-frontierbench.md
+++ b/src/data/issues/2026-06-10-collect-benchmark-frontierbench.md
@@ -1,0 +1,18 @@
+---
+created: 2026-06-10
+agent: collect-benchmark
+severity: minor
+target: llm/frontierbench
+---
+
+## 상황  https://www.anthropic.com/news/claude-fable-5-mythos-5 에 있는 벤치마크 표
+FrontierCode (Diamond)라는 벤치마크 (Agentic coding) 점수가 표에 기재되어 있으나 (Claude Fable 5: 29.3%, Opus 4.8: 13.4%, GPT 5.5: 5.7%), 현재 시스템에 등록된 벤치마크 ID를 찾지 못했습니다.
+"frontierbench" 관련 ID가 없어 점수 등록을 스킵했습니다.
+
+## 시도한 것
+`bun run skills/manage-benchmark/scripts/benchmark.ts list llm | grep frontier`
+
+## 요청  reinforce가 할 구체 작업
+FrontierCode (Diamond) 벤치마크를 시스템에 등록해 주세요. 등록 후 해당 모델들의 점수를 입력해야 합니다.
+
+## 진행 내역

--- a/src/data/issues/2026-06-10-collect-benchmark-healthbench.md
+++ b/src/data/issues/2026-06-10-collect-benchmark-healthbench.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-10
+agent: collect-benchmark
+severity: minor
+target: llm/healthbench-professional
+---
+
+## 상황  https://www.anthropic.com/news/claude-fable-5-mythos-5 에 있는 벤치마크 표
+HealthBench Professional (Health) 점수가 기재되어 있으나 시스템에 해당 벤치마크가 없습니다.
+
+## 시도한 것
+벤치마크 목록 검색
+
+## 요청  reinforce가 할 구체 작업
+HealthBench Professional 벤치마크를 추가해 주세요.

--- a/src/data/journal/2026-06-10-collect-benchmark.md
+++ b/src/data/journal/2026-06-10-collect-benchmark.md
@@ -1,0 +1,36 @@
+---
+date: 2026-06-10
+agent: collect-benchmark
+status: completed
+summary: "Claude Fable 5, Mythos 5, Opus 4.8 벤치마크 점수 매칭 및 Mistral Small 4, Mistral Medium 3.5 점수 매칭 수행 완료"
+---
+
+## Todo
+- [x] 전일(2026-06-09) 등록된 LLM 모델(Claude Fable 5, Mythos 5 등) 및 Mistral 모델의 벤치마크 점수 매칭
+- [x] 출처 URL 없는 벤치마크 누락 건에 대한 이슈 티켓 생성
+
+## 조사 내역
+- 01:30  Anthropic Claude Fable 5 & Mythos 5 벤치마크 표 확인 ← https://www.anthropic.com/news/claude-fable-5-mythos-5 (이미지)
+- 01:35  Mistral Small 4 벤치마크 표 확인 ← https://mistral.ai/news/mistral-small-4/ (이미지)
+- 01:40  Mistral Medium 3.5 벤치마크 수치 확인 ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/
+
+## 수행한 작업
+- [x] `claude-fable-5` 모델 점수 매칭 (swe-bench-pro, gdpval-aa, osworld-verified, legal-agent-bench, hle, terminal-bench-2-1) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] `claude-mythos-5` 모델 점수 매칭 (위와 동일한 점수 적용, Mythos 5/Fable 5가 같은 모델 스펙) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] `claude-mythos-preview` 모델 점수 매칭 (swe-bench-pro, osworld-verified, hle) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] `claude-opus-4-8` 모델 점수 매칭 (swe-bench-pro, gdpval-aa, osworld-verified, legal-agent-bench, hle, terminal-bench-2-1) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] `mistral-small-4` 모델 점수 매칭 (aime-2025, livecodebench-v6) ← https://mistral.ai/news/mistral-small-4/
+- [x] `mistral-medium-3-5` 모델 점수 매칭 (swe-bench-verified, tau-bench-telecom) ← https://mistral.ai/news/vibe-remote-agents-mistral-medium-3-5/
+
+## 판단 / 고민
+- Anthropic 공식 블로그 이미지에서 다수의 신규 벤치마크(FrontierCode, Blueprint-Bench 2, AutomationBench, BioMysteryBench, ExploitBench, HealthBench Professional)가 확인되었으나 시스템에 미등록된 상태.
+- 점수 등록은 보류하고 미등록 벤치마크에 대한 이슈 티켓들을 각각 생성함.
+- Claude Mythos 5 와 Fable 5 는 기반 모델이 동일하고 벤치마크 수치가 함께 명시되어 있으므로 동일 점수 적용 처리.
+
+## 이슈 제기
+- issues/2026-06-10-collect-benchmark-frontierbench.md
+- issues/2026-06-10-collect-benchmark-blueprint-bench-2.md
+- issues/2026-06-10-collect-benchmark-automationbench.md
+- issues/2026-06-10-collect-benchmark-biomysterybench.md
+- issues/2026-06-10-collect-benchmark-exploitbench.md
+- issues/2026-06-10-collect-benchmark-healthbench.md


### PR DESCRIPTION
This PR runs the `collect-benchmark` cycle for 2026-06-10 to match benchmark scores for the LLM models that were recently added or updated.

It extracts scores from the provided Anthropic and Mistral official sources for:
- Claude Fable 5
- Claude Mythos 5
- Claude Mythos Preview
- Claude Opus 4.8
- Mistral Small 4
- Mistral Medium 3.5

Some benchmarks referenced in the source images (like FrontierBench, Blueprint-Bench 2, etc.) were not present in the system. Issue tickets were created for them so they can be registered in a future cycle.

The scores were added using the `benchmark.ts` script as required. The daily journal for `collect-benchmark` was also created.

---
*PR created automatically by Jules for task [13372600929027911450](https://jules.google.com/task/13372600929027911450) started by @GGJJack*