### PR TITLE
Update benchmark definitions and scores for gemma-4-12b and diffusion-gemma

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -756,6 +756,48 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "mmmlu",
+      "name": "MMMLU",
+      "nameKo": "MMMLU (다국어 다중과제 언어 이해)",
+      "category": "knowledge",
+      "description": "MMLU 벤치마크를 다국어로 확장한 버전으로, 다양한 언어로 된 지식 및 추론 능력을 평가합니다.",
+      "source": "https://github.com/openai/simple-evals",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "mmmu-pro",
+      "name": "MMMU Pro",
+      "nameKo": "MMMU Pro",
+      "category": "reasoning",
+      "description": "멀티모달 능력을 평가하는 MMMU의 더 어려운 확장 버전입니다.",
+      "source": "https://mmmu-benchmark.github.io/",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "aime-2026",
+      "name": "AIME 2026",
+      "nameKo": "AIME 2026",
+      "category": "math",
+      "description": "AIME 2026 수학 경시대회 문제입니다.",
+      "source": "https://huggingface.co/datasets/MathArena/aime_2026",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -2630,6 +2672,62 @@
         "date": "2026-03-16",
         "source": "official",
         "url": "https://mistral.ai/news/mistral-small-4/"
+      }
+    },
+    "gemma-4-12b": {
+      "mmlu-pro": {
+        "value": 77.2,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "livecodebench-v6": {
+        "value": 72,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "codeforces": {
+        "value": 1659,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "gpqa": {
+        "value": 78.8,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "tau-bench": {
+        "value": 69,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "hle": {
+        "value": 5.2,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "mmmlu": {
+        "value": 83.4,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "mmmu-pro": {
+        "value": 69.1,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
+      },
+      "aime-2026": {
+        "value": 77.5,
+        "date": "2026-06-03",
+        "source": "official",
+        "url": "https://huggingface.co/google/gemma-4-12B-it"
       }
     }
   }

--- a/src/data/issues/2026-06-12-collect-benchmark-diffusion-gemma.md
+++ b/src/data/issues/2026-06-12-collect-benchmark-diffusion-gemma.md
@@ -1,0 +1,13 @@
+---
+created: 2026-06-12
+agent: collect-benchmark
+severity: blocker
+target: llm/diffusion-gemma
+---
+
+## 상황  https://huggingface.co/google/diffusiongemma-26B-A4B-it
+모델 페이지의 평가 결과 섹션이 view_text_website로 수집한 결과물에서 잘려(Truncated)나와서, 정확한 점수 테이블을 확인할 수 없었습니다.
+## 시도한 것
+Hugging Face 모델 카드를 통해 벤치마크를 수집하려 했으나, 텍스트가 잘려 데이터 검증에 실패했습니다.
+## 요청
+DiffusionGemma에 대한 벤치마크 데이터를 확인하고 수동으로 점수를 추가하거나 텍스트를 제대로 가져올 수 있는 스크립트로 보강해야 합니다.

--- a/src/data/journal/2026-06-12-collect-benchmark.md
+++ b/src/data/journal/2026-06-12-collect-benchmark.md
@@ -1,0 +1,29 @@
+---
+date: 2026-06-12
+agent: collect-benchmark
+status: completed
+summary: "Gemma 4 12B 모델 벤치마크 점수 등록 완료. DiffusionGemma 점수는 출처 확인 불가로 이슈 생성"
+---
+
+## Todo
+- [x] 어제 수집된 신규 모델 `gemma-4-12b` 벤치마크 점수 매칭
+- [x] 어제 수집된 신규 모델 `diffusion-gemma` 벤치마크 점수 매칭
+
+## 조사 내역
+- 01:30 Gemma 4 12B 성능 데이터 확인 ← https://huggingface.co/google/gemma-4-12B-it
+- 01:35 DiffusionGemma 성능 데이터 확인 (페이지 텍스트 잘림) ← https://huggingface.co/google/diffusiongemma-26B-A4B-it
+- 01:40 MMMLU 벤치마크 신규 발견 및 등록 ← https://github.com/openai/simple-evals
+- 01:42 MMMU Pro 벤치마크 신규 발견 및 등록 ← https://mmmu-benchmark.github.io/
+- 01:45 AIME 2026 벤치마크 신규 발견 및 등록 ← https://huggingface.co/datasets/MathArena/aime_2026
+
+## 수행한 작업
+- [x] 신규 벤치마크 등록 `mmmlu`, `mmmu-pro`, `aime-2026`
+- [x] `gemma-4-12b` 점수 9건 추가 (`mmlu-pro`, `aime-2026`, `livecodebench-v6`, `codeforces`, `gpqa`, `tau-bench`, `hle`, `mmmlu`, `mmmu-pro`) ← https://huggingface.co/google/gemma-4-12B-it
+
+## 판단 / 고민
+- MMLU-Pro, LiveCodeBench v6, Codeforces, GPQA, Tau-bench, HLE 벤치마크 점수들이 있어 등록함.
+- AIME 2026, MMMLU, MMMU Pro 등은 현재 등록되지 않은 벤치마크여서 `manage-benchmark create`를 통해 신규 벤치마크로 등록하고 점수를 추가함.
+- DiffusionGemma 모델의 Hugging Face 카드는 view_text_website 툴로 스크랩시 평가 결과 부분이 잘려서 수집되었습니다. 출처 데이터 텍스트에서 직접 확인되지 않은 점수는 저장하지 않아야 하므로 점수 매칭을 취소하고 이슈 티켓을 발행했습니다.
+
+## 이슈 제기
+- issues/2026-06-12-collect-benchmark-diffusion-gemma.md


### PR DESCRIPTION
1. Collected and added verified benchmark scores for the newly added `gemma-4-12b` model.
2. Registered new benchmarks `mmmlu`, `mmmu-pro`, and `aime-2026` as discovered.
3. Handled `diffusion-gemma` by creating an issue ticket due to unverified/truncated source data preventing direct extraction.
4. Created daily journal entry for `collect-benchmark` task.

---
*PR created automatically by Jules for task [7663284297163080654](https://jules.google.com/task/7663284297163080654) started by @GGJJack*