### PR TITLE
feat(profile-benchmark): process daily schedule and handle missing sources

### DIFF
--- a/src/content/benchmarks/aime-2026.md
+++ b/src/content/benchmarks/aime-2026.md
@@ -1,0 +1,16 @@
+---
+benchmarkId: aime-2026
+domain: llm
+status: draft
+updated: 2026-06-12
+sources:
+  - https://huggingface.co/datasets/MathArena/aime_2026
+---
+
+# AIME 2026
+
+## 개요
+AIME 2026 수학 경시대회 문제입니다.
+
+## 평가 방법
+평가 단위는 %를 사용합니다.

--- a/src/data/issues/2026-06-12-profile-benchmark-automationbench.md
+++ b/src/data/issues/2026-06-12-profile-benchmark-automationbench.md
@@ -1,0 +1,11 @@
+---
+created: 2026-06-12
+agent: profile-benchmark
+severity: blocker
+target: llm/automationbench
+---
+
+# automationbench 벤치마크 출처 누락
+
+`automationbench` 벤치마크에 등록된 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크를 찾을 수 없습니다. (소스 텍스트 내에서 "automation" 검색 결과 없음)
+따라서 프로필 페이지 및 관련 조직(organization) 스텁을 생성할 수 없습니다.

--- a/src/data/issues/2026-06-12-profile-benchmark-biomysterybench-hard.md
+++ b/src/data/issues/2026-06-12-profile-benchmark-biomysterybench-hard.md
@@ -1,0 +1,11 @@
+---
+created: 2026-06-12
+agent: profile-benchmark
+severity: blocker
+target: llm/biomysterybench-hard
+---
+
+# biomysterybench-hard 벤치마크 출처 누락
+
+`biomysterybench-hard` 벤치마크에 등록된 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크를 찾을 수 없습니다. (소스 텍스트 내에서 "biomysterybench" 검색 결과 없음)
+따라서 프로필 페이지 및 관련 조직(organization) 스텁을 생성할 수 없습니다.

--- a/src/data/issues/2026-06-12-profile-benchmark-blueprint-bench-2.md
+++ b/src/data/issues/2026-06-12-profile-benchmark-blueprint-bench-2.md
@@ -1,0 +1,11 @@
+---
+created: 2026-06-12
+agent: profile-benchmark
+severity: blocker
+target: llm/blueprint-bench-2
+---
+
+# blueprint-bench-2 벤치마크 출처 누락
+
+`blueprint-bench-2` 벤치마크에 등록된 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크를 찾을 수 없습니다. (소스 텍스트 내에서 "blueprint" 검색 결과 없음)
+따라서 프로필 페이지 및 관련 조직(organization) 스텁을 생성할 수 없습니다.

--- a/src/data/journal/2026-06-12-profile-benchmark.md
+++ b/src/data/journal/2026-06-12-profile-benchmark.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-12
+agent: profile-benchmark
+status: completed
+summary: |
+  - issues/2026-06-12-profile-benchmark-blueprint-bench-2.md 생성 (출처 검증 실패)
+  - issues/2026-06-12-profile-benchmark-automationbench.md 생성 (출처 검증 실패)
+  - issues/2026-06-12-profile-benchmark-biomysterybench-hard.md 생성 (출처 검증 실패)
+  - aime-2026 벤치마크 상세 페이지 작성 ← https://huggingface.co/datasets/MathArena/aime_2026
+---


### PR DESCRIPTION
This PR fulfills the daily `profile-benchmark` schedule for 2026-06-12.

- Identified three benchmarks (`automationbench`, `biomysterybench-hard`, `blueprint-bench-2`) that lacked explicit mention in their listed source URL (Anthropic news). Created issue tickets for them instead of hallucinating data.
- Profiled the `aime-2026` benchmark, fetching its description and unit correctly.
- Updated the daily journal.
- Removed all temporary script artifacts.

---
*PR created automatically by Jules for task [13214334677149672469](https://jules.google.com/task/13214334677149672469) started by @GGJJack*