### PR TITLE
Reinforce maintenance for 2026-06-12

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -22,3 +22,6 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 
 ## 진행 내역 (2026-06-11)
 - (reinforce): Google DeepMind 및 공식 기술 문서 사이트를 재조사하였으나, 여전히 해당 모델(Robotics-ER 1.6)에 대한 MMLU, GPQA 등 표준 LLM 벤치마크 점수는 공개되지 않음. 로보틱스 특화 성능 지표 또한 수치화된 공식 데이터가 확인되지 않아 추적을 지속함.
+
+## 진행 내역 (2026-06-12)
+- (reinforce): 2026년 6월 4일 업데이트된 공식 문서(https://ai.google.dev/gemini-api/docs/robotics-overview)를 재확인하였으나, 여전히 MMLU, GPQA 등 표준 LLM 벤치마크 점수는 누락됨. 해당 모델은 공간 추론, 궤적 생성 등 로보틱스 에이전트 기능에 특화되어 있으며, 일반 언어 모델 성능 지표는 의도적으로 배제된 것으로 보임.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -46,3 +46,6 @@ target: llm/multiple
 - (reinforce): OpenAI 공식 가격 페이지(https://openai.com/api/pricing/)를 통해 GPT-5.5의 정식 가격($5/$30 per 1M tokens)을 확인하여 업데이트함.
 - HyperCLOVA X, Yi-Large, Baichuan-4의 공식 API 가격은 여전히 상담 또는 콘솔 로그인이 필요한 비공개 상태임.
 - GPT-5-5-instant 등 대기 중이던 OpenAI 모델들의 가격 정보를 최신화함.
+
+## 진행 내역 (2026-06-12)
+- (reinforce): NCP CLOVA Studio 공식 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio)를 재점검하였으나, HCX-007, HCX-005, HCX-DASH-002 등의 요금은 여전히 '-'로 표시되어 있으며 구체적인 수치는 공개되지 않음. Yi-Large 및 Baichuan-4 역시 공식 웹사이트와 OpenRouter에서 새로운 가격 변동이나 공식 확정 공지가 확인되지 않아 기존 추정치를 유지함.

--- a/src/data/journal/2026-06-12-reinforce.md
+++ b/src/data/journal/2026-06-12-reinforce.md
@@ -1,0 +1,25 @@
+---
+title: "2026-06-12 reinforce"
+status: completed
+---
+
+# reinforce (2026-06-12)
+
+오늘 처리한 이슈 목록과 결과입니다.
+
+## 처리 이슈
+
+1. **Partial: gemini-robotics-er-1-6 (2026-05-05)**
+   - 내용: Gemini Robotics-ER 1.6 의 벤치마크 점수 탐색
+   - 조치: 2026년 6월 4일자 공식 문서 재점검. 여전히 표준 LLM 벤치마크(MMLU 등)는 미공개 상태임을 확인.
+   - 업데이트: 모델 메타데이터(contextWindow 131,072, official link) 보강 및 진행 내역 기록.
+
+2. **Partial: multiple-llm-pricing (2026-05-06)**
+   - 내용: HyperCLOVA X, Yi-Large, Baichuan-4 가격 보강
+   - 조치: NCP CLOVA Studio 및 OpenRouter 재조사. 공식 확정된 신규 요금 체계는 확인되지 않아 기존 추정치 유지 및 진행 내역 기록.
+
+## 데이터 변경 내역
+
+- **llm/gemini-robotics-er-1-6**: contextWindow (1048576 -> 131072), official link (update)
+- **issue/2026-05-05-...**: 진행 내역 추가
+- **issue/2026-05-06-...**: 진행 내역 추가

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -644,13 +644,13 @@
     },
     {
       "parameterSize": null,
-      "contextWindow": 1048576,
+      "contextWindow": 131072,
       "pricing": {
         "input": 1,
         "output": 5
       },
       "links": {
-        "official": "https://ai.google.dev/gemini-api/docs/models/gemini#gemini-robotics-er-1-6"
+        "official": "https://ai.google.dev/gemini-api/docs/robotics-overview"
       },
       "id": "gemini-robotics-er-1-6",
       "name": "Gemini Robotics-ER 1.6",


### PR DESCRIPTION
Completed the reinforcement task for June 12, 2026.
- Researched Gemini Robotics-ER 1.6: Updated metadata (context window 131k, new official link) based on June 2026 docs. Confirmed standard benchmarks remain unlisted.
- Researched HyperCLOVA X, Yi-Large, Baichuan-4: Verified that official public pricing for HyperCLOVA X is still unavailable (consultation-based), and maintained existing estimates for others.
- Updated issue tickets 2026-05-05 and 2026-05-06 with latest research findings.
- Generated the daily reinforcement journal.
- Verified project integrity with 'bun run build'.

Fixes #472

---
*PR created automatically by Jules for task [16177783697579563415](https://jules.google.com/task/16177783697579563415) started by @GGJJack*