### PR TITLE
Add diffusion-gemma benchmark scores

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -2729,6 +2729,62 @@
         "source": "official",
         "url": "https://huggingface.co/google/gemma-4-12B-it"
       }
+    },
+    "diffusion-gemma": {
+      "mmlu-pro": {
+        "value": 77.6,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "aime-2026": {
+        "value": 69.1,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "livecodebench-v6": {
+        "value": 69.1,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "codeforces": {
+        "value": 1429,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "gpqa": {
+        "value": 73.2,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "tau-bench": {
+        "value": 56.2,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "hle": {
+        "value": 11,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "mmmlu": {
+        "value": 81.5,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      },
+      "mmmu-pro": {
+        "value": 54.3,
+        "date": "2026-06-13",
+        "source": "official",
+        "url": "https://huggingface.co/google/diffusiongemma-26B-A4B-it"
+      }
     }
   }
 }

--- a/src/data/journal/2026-06-13-collect-benchmark.md
+++ b/src/data/journal/2026-06-13-collect-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-13
+agent: collect-benchmark
+status: completed
+summary: "DiffusionGemma 벤치마크 점수 9건 등록 완료"
+---
+
+## Todo
+- [x] 누락된 신규 모델 `diffusion-gemma` 벤치마크 점수 매칭
+
+## 조사 내역
+- 01:30 DiffusionGemma 성능 데이터 raw markdown으로 확인 (Hugging Face README) ← https://huggingface.co/google/diffusiongemma-26B-A4B-it
+
+## 수행한 작업
+- [x] `diffusion-gemma` 점수 9건 추가 (`mmlu-pro`, `aime-2026`, `livecodebench-v6`, `codeforces`, `gpqa`, `tau-bench`, `hle`, `mmmlu`, `mmmu-pro`) ← https://huggingface.co/google/diffusiongemma-26B-A4B-it
+
+## 판단 / 고민
+- 전날 view_text_website 텍스트 잘림 현상으로 실패했던 모델의 점수를 curl 로 raw markdown 파일을 페치하여 확인 및 등록함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Added 9 benchmark scores for `diffusion-gemma` using `benchmark.ts` and created the journal file for `2026-06-13`. The model scores were found directly on the official Hugging Face repository README.

---
*PR created automatically by Jules for task [9756759724297239413](https://jules.google.com/task/9756759724297239413) started by @GGJJack*