### PR TITLE
Profile new models: Mistral 3 and Gemini 3.5 Live Translate

### DIFF
--- a/src/content/models/gemini-3-5-live-translate.md
+++ b/src/content/models/gemini-3-5-live-translate.md
@@ -1,0 +1,35 @@
+---
+modelId: gemini-3-5-live-translate
+domain: llm
+status: published
+updated: 2026-06-14
+sources:
+  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-live-3-5-translate/
+  - https://deepmind.google/models/model-cards/gemini-3-5-audio/
+  - https://ai.google.dev/gemini-api/docs/live-api/live-translate
+features:
+  toolUse: false
+  vision: false
+  audioInput: true
+  audioOutput: true
+  realtime: true
+highlights:
+  - "70개 이상의 언어 지원 실시간 음성 통역 모델"
+  - "화자의 억양, 속도, 피치를 유지하는 자연스러운 음성 생성"
+  - "SynthID를 통한 AI 생성 오디오 워터마크 적용"
+relatedOrganization: google
+---
+
+# Gemini 3.5 Live Translate 소개
+
+## 개요
+Gemini 3.5 Live Translate는 Google이 2026년 6월 9일에 발표한 혁신적인 오디오 전용 실시간 통역 모델입니다. Gemini 3 Pro를 기반으로 설계된 이 모델은 70개 이상의 언어를 자동으로 감지하고, 화자 간의 언어 장벽을 허물어 자연스러운 대화를 가능하게 합니다. 기존의 순차적 번역 시스템과 달리, 상대방의 말이 끝나기를 기다리지 않고 지속적으로 음성을 처리하여 지연 시간을 최소화한 것이 특징입니다.
+
+## 기술 특징
+이 모델은 음성 스트림을 실시간으로 처리하며, 번역된 음성에서 화자의 고유한 억양(Intonation), 속도(Pacing), 피치(Pitch)를 유지하여 기계적인 느낌을 줄였습니다. 기술적으로는 최대 128k 토큰의 오디오 컨텍스트 윈도우를 지원하며, 출력 시에는 최대 64k 토큰의 오디오 및 텍스트를 생성할 수 있습니다. 특히 노이즈에 대한 강한 내성을 갖추고 있어 소음이 심한 환경에서도 정확한 번역이 가능합니다. 또한 보안과 투명성을 위해 모든 생성 오디오에는 SynthID 워터마크가 보이지 않게 삽입되어 있습니다.
+
+## 사용 사례
+Gemini 3.5 Live Translate는 다양한 실시간 커뮤니케이션 환경에 최적화되어 있습니다. Google Meet을 통한 화상 회의에서 2,000개 이상의 언어 조합으로 실시간 통역을 지원하며, Google 번역 앱의 '듣기 모드'를 통해 스마트폰을 귀에 대고 일반 통화처럼 외국어 안내를 자국어로 실시간 청취할 수 있습니다. 개발자들은 Gemini Live API를 통해 다국어 전화 통화, 교육 강의 라이브 통역, 방송 더빙 등의 서비스에 이 모델의 기능을 통합할 수 있습니다.
+
+## 한계
+이 모델은 오디오 입력에 특화되어 있어 텍스트 입력은 지원하지 않으며, 현재 도구 사용(Tool-use)이나 복잡한 시스템 명령 수행 기능은 갖추고 있지 않습니다. 또한 긴 일시 정지 후에는 목소리가 일관되지 않거나, 여러 명의 화자가 빠르게 교차하며 말하는 상황에서 성별 인식이 바뀌는 등의 기술적 한계가 보고되어 있습니다. 배경 소음을 효과적으로 필터링하지만, 특정 환경에서는 번역된 오디오에 노이즈가 섞일 수 있습니다.

--- a/src/content/models/mistral-3.md
+++ b/src/content/models/mistral-3.md
@@ -1,0 +1,35 @@
+---
+modelId: mistral-3
+domain: llm
+status: published
+updated: 2026-06-14
+sources:
+  - https://mistral.ai/news/mistral-3/
+  - https://huggingface.co/collections/mistralai/ministral-3
+  - https://arxiv.org/abs/2601.08584
+features:
+  toolUse: true
+  vision: true
+  audioInput: false
+  audioOutput: false
+  fineTuning: true
+highlights:
+  - "Mistral Large 3(MoE)와 Ministral 3(Dense) 시리즈 포함"
+  - "전 모델 Apache 2.0 라이선스 적용"
+  - "이미지 이해 및 40개 이상의 다국어 지원"
+relatedOrganization: mistral-ai
+---
+
+# Mistral 3 시리즈 소개
+
+## 개요
+Mistral 3는 Mistral AI가 2025년 12월에 발표한 차세대 모델 제품군입니다. 이 시리즈는 최상위 성능의 거대 모델인 'Mistral Large 3'와 에지(Edge) 및 로컬 환경에 최적화된 소형 모델인 'Ministral 3' 시리즈(14B, 8B, 3B)를 모두 포함합니다. Mistral 3 제품군의 모든 모델은 Apache 2.0 라이선스로 공개되어, 개발자들이 자유롭게 상업적 이용 및 최적화를 수행할 수 있도록 지원합니다.
+
+## 기술 특징
+Mistral 3 시리즈는 사용 목적에 따라 두 가지 주요 아키텍처를 채택했습니다. Mistral Large 3는 675B 총 파라미터(41B 활성 파라미터)를 가진 희소 혼합 전문가(MoE) 구조로 설계되어 프론티어급 성능을 제공합니다. 반면 Ministral 3 시리즈는 3B, 8B, 14B 크기의 고밀도(Dense) 모델로, 에지 디바이스에서의 고성능 추론을 목적으로 합니다. 전 모델이 이미지 이해(Vision) 역량을 기본으로 갖추고 있으며, 40개 이상의 언어를 지원하는 강력한 다국어 능력을 보여줍니다. 또한 NVIDIA와의 협업을 통해 TensorRT-LLM 및 SGLang 등의 최신 추론 엔진에 최적화되었습니다.
+
+## 사용 사례
+이 제품군은 데이터 센터부터 온디바이스 AI까지 폭넓은 사용 사례를 지원합니다. Mistral Large 3는 복잡한 추론, 대규모 코딩 프로젝트, 고도화된 에이전트 워크플로우에 적합하며, Ministral 3 시리즈는 스마트폰, 노트북, 로봇 등 로컬 환경에서의 실시간 번역, 문서 요약, 시각적 보조 기능 구현에 최적화되어 있습니다. 특히 추론 시 생성되는 토큰 수를 줄이면서도 정확도를 높여 비용 효율적인 서비스 구축이 가능합니다.
+
+## 한계
+Ministral 3 시리즈는 소형 모델임에도 뛰어난 성능을 보이지만, 매우 복잡한 논리 추론이나 전문적인 지식이 필요한 작업에서는 Mistral Large 3나 전용 추론 모델인 Reasoning 변체(Coming soon 언급)에 비해 성능이 낮을 수 있습니다. 또한 모든 모델이 이미지 이해는 가능하나, 비디오 이해나 오디오 입력을 직접 처리하는 네이티브 멀티모달 기능은 갖추고 있지 않습니다.

--- a/src/data/journal/2026-06-14-profile-model.md
+++ b/src/data/journal/2026-06-14-profile-model.md
@@ -1,0 +1,39 @@
+---
+date: 2026-06-14
+agent: profile-model
+status: completed
+summary: "Mistral 3 및 Gemini 3.5 Live Translate 상세 페이지 작성 및 데이터 보정 완료"
+---
+
+## Todo
+- [x] Mistral 3 프로파일 작성
+- [x] Gemini 3.5 Live Translate 프로파일 작성
+- [x] 스키마 검증 및 요약
+
+## 조사 내역
+- 11:00 작업 시작
+- 11:05 Mistral 3 공식 블로그 확인 (https://mistral.ai/news/mistral-3)
+  - 2025년 12월 2일 발표.
+  - Mistral Large 3 (675B MoE, 41B 활성) 및 Ministral 3 (14B, 8B, 3B dense) 포함.
+  - Apache 2.0 라이선스 명시.
+- 11:10 Gemini 3.5 Live Translate 공식 블로그 확인 (https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-live-3-5-translate/)
+  - 2026년 6월 9일 발표.
+  - 70개 이상의 언어 감지 및 실시간 통역.
+  - 음성 고유의 톤, 속도, 피치 유지.
+  - SynthID 워터마크 적용.
+- 11:15 DeepMind 모델 카드 확인 (https://deepmind.google/models/model-cards/gemini-3-5-audio/)
+  - Gemini 3 Pro 기반, 128k 오디오 입력 컨텍스트.
+
+## 수행한 작업
+- [x] `src/content/models/mistral-3.md` 생성 (published)
+- [x] `src/content/models/gemini-3-5-live-translate.md` 생성 (published)
+- [x] `src/data/models/llm.json` 내 `mistral-3` 라이선스 수정 (`Apache-2.0`)
+- [x] `bun run build`를 통한 Zod 스키마 검증 완료
+
+## 판단 / 고민
+- Mistral 3의 경우 여러 모델을 포괄하는 이름으로 보임. 상세 페이지에서는 이 계열 전체를 아우르는 개요를 작성함.
+- Gemini 3.5 Live Translate는 오디오 전용 모델이나 LLM 도메인으로 등록되어 있어 해당 맥락에서 서술.
+- Mistral 3의 라이선스 불일치를 확인하여 레지스트리 데이터를 직접 수정함.
+
+## 이슈 제기
+- (없음)

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -2878,7 +2878,7 @@
       "name": "Mistral 3",
       "provider": "Mistral AI",
       "releaseDate": "2025-12-02",
-      "license": "Mistral Non-Production License"
+      "license": "Apache-2.0"
     },
     {
       "parameterSize": null,


### PR DESCRIPTION
Created two new model profiles (Mistral 3 and Gemini 3.5 Live Translate) with high-quality sources and Korean descriptions. Corrected a license discrepancy for Mistral 3 in the JSON registry. All changes verified through build and visual inspection.

Fixes #489

---
*PR created automatically by Jules for task [4668191743906810081](https://jules.google.com/task/4668191743906810081) started by @GGJJack*