### PR TITLE
Create missing benchmark issues for healthbench-professional and biomysterybench-human

### DIFF
--- a/src/data/issues/2026-06-15-profile-benchmark-biomysterybench-human.md
+++ b/src/data/issues/2026-06-15-profile-benchmark-biomysterybench-human.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-15
+agent: profile-benchmark
+severity: blocker
+target: llm/biomysterybench-human
+---
+
+벤치마크 `biomysterybench-human`에 대한 상세 페이지를 작성하려 했으나, 등록된 공식 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)의 텍스트 본문에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다 (이미지 형태로만 존재). 출처 URL의 텍스트 내용을 확인했으나 벤치마크를 텍스트로 검증할 수 없어 프로파일 생성을 중단했습니다. 해당 벤치마크 데이터에 대한 텍스트 기반 공식 출처 확인이 필요합니다.

--- a/src/data/issues/2026-06-15-profile-benchmark-healthbench-professional.md
+++ b/src/data/issues/2026-06-15-profile-benchmark-healthbench-professional.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-15
+agent: profile-benchmark
+severity: blocker
+target: llm/healthbench-professional
+---
+
+벤치마크 `healthbench-professional`에 대한 상세 페이지를 작성하려 했으나, 등록된 공식 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)의 텍스트 본문에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다 (이미지 형태로만 존재). 출처 URL의 텍스트 내용을 확인했으나 벤치마크를 텍스트로 검증할 수 없어 프로파일 생성을 중단했습니다. 해당 벤치마크 데이터에 대한 텍스트 기반 공식 출처 확인이 필요합니다.

--- a/src/data/journal/2026-06-15-profile-benchmark.md
+++ b/src/data/journal/2026-06-15-profile-benchmark.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-15
+agent: profile-benchmark
+status: completed
+summary: "healthbench-professional, biomysterybench-human 출처 텍스트 부재로 인한 이슈 티켓 생성"
+---
+
+## 수행한 작업
+- healthbench-professional 출처 본문 확인 실패 (이미지만 존재) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- biomysterybench-human 출처 본문 확인 실패 (이미지만 존재) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 이슈 제기
+- issues/2026-06-15-profile-benchmark-healthbench-professional.md
+- issues/2026-06-15-profile-benchmark-biomysterybench-human.md


### PR DESCRIPTION
Created missing benchmark issues for healthbench-professional and biomysterybench-human.

- Created `healthbench-professional` blocker issue ticket because the benchmark is not explicitly mentioned in the source URL's text.
- Created `biomysterybench-human` blocker issue ticket because the benchmark is not explicitly mentioned in the source URL's text.
- Created `2026-06-15-profile-benchmark.md` journal file logging these tasks.

---
*PR created automatically by Jules for task [6456007422983643889](https://jules.google.com/task/6456007422983643889) started by @GGJJack*