### PR TITLE
Add profiles for Voxtral Mini Transcribe 2 models

### DIFF
--- a/src/content/models/voxtral-mini-transcribe-2.md
+++ b/src/content/models/voxtral-mini-transcribe-2.md
@@ -1,0 +1,33 @@
+---
+modelId: voxtral-mini-transcribe-2
+domain: multimodal
+status: published
+updated: 2026-06-15
+sources:
+  - https://mistral.ai/news/voxtral-transcribe-2/
+  - https://docs.mistral.ai/models/voxtral-mini-transcribe-26-02
+  - https://console.mistral.ai/build/audio/speech-to-text
+features:
+  audioInput: true
+  audioOutput: false
+  realtime: false
+highlights:
+  - "Mistral의 차세대 배치용 음성-텍스트(STT) 모델"
+  - "화자 분리(Diarization), 단어 단위 타임스탬프 지원"
+  - "13개 언어 지원 및 높은 노이즈 내성"
+relatedOrganization: mistral-ai
+---
+
+# Voxtral Mini Transcribe 2 소개
+
+## 개요
+Voxtral Mini Transcribe 2는 Mistral AI가 2026년 2월 4일에 발표한 차세대 배치형 음성 인식(STT) 모델입니다. 이전 세대 대비 비약적인 정확도 향상과 비용 효율성을 달성하였으며, 특히 13개 주요 언어에 대해 업계 최고 수준의 단어 오류율(WER)을 기록했습니다. 이 모델은 대규모 오디오 데이터를 빠르고 정확하게 텍스트로 변환해야 하는 비즈니스 워크플로우에 최적화되어 있습니다.
+
+## 기술 특징
+이 모델은 배치 처리에 특화되어 최대 3시간 분량의 오디오를 단일 요청으로 처리할 수 있습니다. 주요 기술적 특징으로는 정교한 **화자 분리(Speaker Diarization)** 기능을 통해 여러 명의 화자가 대화하는 상황에서도 각 발화자를 정확히 구분하며, 단어 단위의 타임스탬프를 제공하여 자막 제작이나 오디오 검색에 활용할 수 있습니다. 또한 **컨텍스트 바이어싱(Context Biasing)** 기능을 통해 고유 명사나 전문 용어의 인식률을 높일 수 있는 기능을 갖추고 있습니다. Mistral AI의 벤치마크에 따르면 FLEURS 데이터셋에서 약 4%의 WER을 기록하며 경쟁 모델 대비 우수한 성능을 입증했습니다.
+
+## 사용 사례
+Voxtral Mini Transcribe 2는 회의록 자동 작성, 인터뷰 분석, 고객 센터의 녹취록 생성 등 정교한 사후 처리가 필요한 도메인에서 널리 사용됩니다. 특히 화자 분리 기능은 다자간 회의에서 누가 어떤 발언을 했는지 기록하는 데 유용하며, 저렴한 비용($0.003/min) 덕분에 대량의 미디어 자산을 아카이빙하고 인덱싱하는 용도로 적합합니다.
+
+## 한계
+이 모델은 배치 처리에 최적화되어 있어 실시간 스트리밍 통역이나 즉각적인 반응이 필요한 서비스에는 적합하지 않으며, 해당 용도로는 Voxtral Realtime 모델이 권장됩니다. 또한 여러 화자가 동시에 말을 하는 겹침(Overlapping) 상황에서는 모든 화자를 개별적으로 분리하기보다 주된 화자 한 명의 발화만을 인식하는 경향이 있습니다. 컨텍스트 바이어싱 기능은 현재 영어에 최적화되어 있으며 다른 언어에서는 실험적인 수준입니다.

--- a/src/content/models/voxtral-mini-transcribe-realtime.md
+++ b/src/content/models/voxtral-mini-transcribe-realtime.md
@@ -1,0 +1,33 @@
+---
+modelId: voxtral-mini-transcribe-realtime
+domain: multimodal
+status: published
+updated: 2026-06-15
+sources:
+  - https://mistral.ai/news/voxtral-transcribe-2/
+  - https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602
+  - https://docs.mistral.ai/models/voxtral-mini-transcribe-realtime-26-02
+features:
+  audioInput: true
+  audioOutput: false
+  realtime: true
+highlights:
+  - "Apache 2.0 라이선스의 오픈 가중치 실시간 STT 모델"
+  - "최저 200ms 미만의 지연시간(Latency) 지원"
+  - "4B 파라미터 규모로 에지 디바이스 실행 가능"
+relatedOrganization: mistral-ai
+---
+
+# Voxtral Realtime 소개
+
+## 개요
+Voxtral Realtime(공식 명칭 Voxtral Mini Transcribe Realtime)은 Mistral AI가 2026년 2월 4일에 공개한 실시간 스트리밍 전용 음성 인식(STT) 모델입니다. 기존의 오프라인 모델을 잘게 쪼개어 처리하는 방식이 아닌, 오디오 데이터가 도착하는 즉시 처리하는 고유한 스트리밍 아키텍처를 채택했습니다. 특히 Apache 2.0 라이선스로 공개되어 상업적 이용과 로컬 환경 배포가 자유로운 것이 큰 장점입니다.
+
+## 기술 특징
+이 모델은 4B 파라미터 규모로 설계되어 스마트폰이나 노트북과 같은 에지 디바이스에서도 효율적으로 작동합니다. 가장 큰 특징은 **가변 지연시간(Configurable Latency)**으로, 사용 환경에 따라 지연시간을 200ms 미만까지 낮출 수 있어 실시간 대화형 AI 시스템에 최적입니다. 지연시간을 2.4초로 설정할 경우 배치 모델인 Voxtral Mini Transcribe 2에 근접하는 정확도를 보여주며, 480ms 수준에서도 높은 정확도를 유지합니다. 한국어를 포함한 13개 언어를 기본 지원하며, 노이즈가 많은 환경에서도 안정적인 성능을 발휘합니다.
+
+## 사용 사례
+Voxtral Realtime은 실시간성이 중요한 모든 음성 인터페이스에 활용됩니다. 대표적으로 대화형 AI 에이전트, 실시간 자막 생성, 다국어 라이브 방송 더빙 보조 등에 사용됩니다. 특히 오픈 가중치 모델이기 때문에 데이터 보안이 중요한 기업 내부용 실시간 회의 지원 도구나 오프라인 상태에서 작동해야 하는 임베디드 기기의 음성 명령 인식 엔진으로도 강력한 경쟁력을 가집니다.
+
+## 한계
+실시간 처리에 특화된 만큼, 긴 오디오 파일을 한꺼번에 처리하는 배치 작업에서는 배치 전용 모델보다 처리 효율이 낮을 수 있습니다. 또한 매우 짧은 지연시간을 설정할 경우(예: 200ms 미만), 문맥 파악 능력이 다소 감소하여 지연시간이 긴 설정에 비해 단어 오류율(WER)이 소폭 상승할 수 있습니다. 배치 모델과 마찬가지로 화자가 동시에 말을 하는 복잡한 오디오 환경에서의 완벽한 분리에는 한계가 있습니다.

--- a/src/data/journal/2026-06-15-profile-model.md
+++ b/src/data/journal/2026-06-15-profile-model.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-15
+agent: profile-model
+status: completed
+summary: "Voxtral Mini Transcribe 2 및 Realtime 모델 상세 페이지 작성 완료"
+---
+
+## Todo
+- [x] voxtral-mini-transcribe-2 상세 페이지 작성
+- [x] voxtral-mini-transcribe-realtime 상세 페이지 작성
+- [x] 빌드 및 검증
+
+## 조사 내역
+- 10:45 Mistral AI의 Voxtral Transcribe 2 발표 블로그 확인 ← https://mistral.ai/news/voxtral-transcribe-2/
+- 10:46 Voxtral Mini Transcribe 2: 배치 작업용, $0.003/min, 13개 언어 지원 확인
+- 10:46 Voxtral Realtime: 실시간 작업용, $0.006/min, Apache 2.0 라이선스, sub-200ms 지연시간 확인
+
+## 수행한 작업
+- [x] `src/content/models/voxtral-mini-transcribe-2.md` 생성
+- [x] `src/content/models/voxtral-mini-transcribe-realtime.md` 생성
+- [x] `bun run build`를 통한 Zod 스키마 검증 및 정적 페이지 생성 확인
+
+## 판단 / 고민
+- 두 모델의 특징이 겹치는 부분이 많으나, 하나는 배치 중심이고 하나는 실시간 스트리밍 중심이므로 별도 페이지로 작성함.
+- `license` 및 `releaseDate` 정보는 `src/data/models/` 내의 JSON 레지스트리에서 관리되므로 Markdown frontmatter에는 포함하지 않음 (Zod 스키마 준수).
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Added detailed Korean profile pages for Mistral AI's Voxtral Mini Transcribe 2 and Voxtral Realtime models. The profiles include technical characteristics, use cases, and official source links. Verification was performed using Astro build and Playwright screenshots.

Fixes #498

---
*PR created automatically by Jules for task [3452735826403144020](https://jules.google.com/task/3452735826403144020) started by @GGJJack*