### PR TITLE
feat: generate daily report for 2026-06-16 and update journal

### DIFF
--- a/src/data/journal/2026-06-17-journal.md
+++ b/src/data/journal/2026-06-17-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-17
+agent: journal
+status: completed
+summary: "2026-06-16 데일리 리포트 생성 완료"
+---
+
+## 수행한 작업
+- [x] `src/data/updates/2026-06-16-daily.md` 파일 생성 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-06-16-daily.md
+++ b/src/data/updates/2026-06-16-daily.md
@@ -1,0 +1,34 @@
+---
+date: 2026-06-16
+type: note
+title: 데일리 리포트 · 2026-06-16
+summary: 금일(2026-06-16) 신규 수집된 LLM 모델이 없어 점수 매칭 작업 건너뜀 / 2026-06-16 collect-llm / AutomationBench 및 BioMysteryBench (Hard) 상세 페이지 작성 / North Mini Code 및 MiniMax M3 상세 페이지 작성 완료
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 신규: north-mini-code (Cohere) ← https://cohere.com/blog/north-mini-code
+- 신규: minimax-m3 (MiniMax) ← https://www.minimaxi.com/models/text/m3
+- 신규: lfm2-5-8b-a1b (Liquid AI) ← https://www.liquid.ai/blog/lfm2-5-8b-a1b
+- 보강: claude-fable-5 (Anthropic) · contextWindow: 200,000 → 1,000,000 (Artificial Analysis 및 공식 블로그 확인) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 보강: claude-mythos-5 (Anthropic) · contextWindow: 200,000 → 1,000,000 (Mythos-class 사양 일치 확인)
+- 보강: diffusion-gemma (Google) · pricing: null → {input: 0, output: 0} (공식 발표 기준 무료 오픈 모델) ← https://deepmind.google/blog/diffusiongemma-4x-faster-text-generation/
+
+### 벤치마크 (collect-benchmark)
+- [x] 업데이트 대상 모델이 없음을 확인하고 종료
+
+## 상세 페이지 작성 (profile)
+- [x] `automationbench` 상세 페이지 작성
+- [x] `biomysterybench-hard` 상세 페이지 작성
+- [x] Zapier 기관 이슈 티켓 생성
+- [x] `src/content/models/north-mini-code.md` 생성 및 `status: published` 설정
+- [x] `src/content/models/minimax-m3.md` 생성 및 `status: published` 설정
+- [x] `bun run build`를 통한 스키마 및 빌드 검증 완료
+- [x] Playwright를 이용한 로컬 렌더링 확인 (캡처 완료)
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 0건
+
+## 미해결 이슈
+- (없음)


### PR DESCRIPTION
Generates the daily report for yesterday (2026-06-16) by extracting activities and issues from `collect-*`, `profile-*`, and `reinforce` journals, ensuring that numbers are strictly extracted from the journals, and that proper URLs are included. Also correctly marks the own 2026-06-17 agent journal as completed.

---
*PR created automatically by Jules for task [2798775562328654666](https://jules.google.com/task/2798775562328654666) started by @GGJJack*