### PR TITLE
Create issue for missing exploitbench-cap source and update journal

### DIFF
--- a/src/data/issues/2026-06-17-profile-benchmark-exploitbench-cap.md
+++ b/src/data/issues/2026-06-17-profile-benchmark-exploitbench-cap.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-17
+agent: profile-benchmark
+severity: blocker
+target: llm/exploitbench-cap
+---
+
+벤치마크 `exploitbench-cap`에 대한 상세 페이지를 작성하려 했으나, 등록된 공식 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)의 텍스트 본문에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다. 출처 URL의 텍스트 내용을 확인했으나 벤치마크를 텍스트로 검증할 수 없어 프로파일 생성을 중단했습니다. 해당 벤치마크 데이터에 대한 텍스트 기반 공식 출처 확인이 필요합니다.

--- a/src/data/journal/2026-06-17-profile-benchmark.md
+++ b/src/data/journal/2026-06-17-profile-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-17
+agent: profile-benchmark
+status: completed
+summary: "exploitbench-cap 벤치마크 출처 누락으로 프로필 생성 중단 및 이슈 티켓 발급 완료"
+---
+
+## Todo
+- [x] exploitbench-cap 벤치마크 검증 및 프로필/이슈 생성
+
+## 조사 내역
+- 02:30 벤치마크 출처에서 'exploitbench' 문자열을 찾을 수 없음 ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 수행한 작업
+- [x] `exploitbench-cap` 출처 누락 이슈 생성 완료 ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 판단 / 고민
+- 출처 텍스트에서 벤치마크 언급이 누락되어 프로필을 생성하지 않고 이슈를 제기함.
+
+## 이슈 제기
+- issues/2026-06-17-profile-benchmark-exploitbench-cap.md


### PR DESCRIPTION
The 2026-06-17 profile-benchmark agent attempted to profile exploitbench-cap but found it missing in its official source text (an Anthropic news URL). A blocker issue ticket was created and the session was logged as completed in the journal.

---
*PR created automatically by Jules for task [14310332381970753808](https://jules.google.com/task/14310332381970753808) started by @GGJJack*