### PR TITLE
Create issue tickets for unverified benchmarks missing from Anthropic source

### DIFF
--- a/src/data/issues/2026-06-18-profile-benchmark-biomysterybench-human.md
+++ b/src/data/issues/2026-06-18-profile-benchmark-biomysterybench-human.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-18
+agent: profile-benchmark
+severity: blocker
+target: llm/biomysterybench-human
+---
+
+The source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) does not explicitly mention the `biomysterybench-human` benchmark. Fetched the content of the source URL and searched for the benchmark name "biomysterybench-human" but found no matches.
+Provide the correct official source URL that contains the `biomysterybench-human` benchmark data.

--- a/src/data/issues/2026-06-18-profile-benchmark-blueprint-bench-2.md
+++ b/src/data/issues/2026-06-18-profile-benchmark-blueprint-bench-2.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-18
+agent: profile-benchmark
+severity: blocker
+target: llm/blueprint-bench-2
+---
+
+The source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) does not explicitly mention the `blueprint-bench-2` benchmark. Fetched the content of the source URL and searched for the benchmark name "blueprint-bench-2" but found no matches.
+Provide the correct official source URL that contains the `blueprint-bench-2` benchmark data.

--- a/src/data/issues/2026-06-18-profile-benchmark-exploitbench-cap.md
+++ b/src/data/issues/2026-06-18-profile-benchmark-exploitbench-cap.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-18
+agent: profile-benchmark
+severity: blocker
+target: llm/exploitbench-cap
+---
+
+The source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) does not explicitly mention the `exploitbench-cap` benchmark. Fetched the content of the source URL and searched for the benchmark name "exploitbench-cap" but found no matches.
+Provide the correct official source URL that contains the `exploitbench-cap` benchmark data.

--- a/src/data/issues/2026-06-18-profile-benchmark-gdp-pdf.md
+++ b/src/data/issues/2026-06-18-profile-benchmark-gdp-pdf.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-18
+agent: profile-benchmark
+severity: blocker
+target: llm/gdp-pdf
+---
+
+The source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) does not explicitly mention the `gdp-pdf` benchmark. Fetched the content of the source URL and searched for the benchmark name "gdp-pdf" but found no matches.
+Provide the correct official source URL that contains the `gdp-pdf` benchmark data.

--- a/src/data/issues/2026-06-18-profile-benchmark-healthbench-professional.md
+++ b/src/data/issues/2026-06-18-profile-benchmark-healthbench-professional.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-18
+agent: profile-benchmark
+severity: blocker
+target: llm/healthbench-professional
+---
+
+The source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) does not explicitly mention the `healthbench-professional` benchmark. Fetched the content of the source URL and searched for the benchmark name "healthbench-professional" but found no matches.
+Provide the correct official source URL that contains the `healthbench-professional` benchmark data.

--- a/src/data/journal/2026-06-18-profile-benchmark.md
+++ b/src/data/journal/2026-06-18-profile-benchmark.md
@@ -1,0 +1,29 @@
+---
+date: 2026-06-18
+agent: profile-benchmark
+status: completed
+summary: "Created issue tickets due to unverified sources for gdp-pdf, blueprint-bench-2, biomysterybench-human, exploitbench-cap, healthbench-professional"
+---
+
+## Todo
+## 조사 내역
+- 02:30 JSON output of missing benchmarks
+- 02:30 Fetched and parsed Anthropic Claude Fable 5 & Mythos 5 news release ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 02:30 Confirmed that benchmarks are not mentioned in the source text.
+
+## 수행한 작업
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-gdp-pdf.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-blueprint-bench-2.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-biomysterybench-human.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-exploitbench-cap.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-healthbench-professional.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 판단 / 고민
+Sources provided in JSON data do not contain mentions of the specific benchmarks. Thus, I skipped creating markdown profiles and instead raised blocker issues.
+
+## 이슈 제기
+- issues/2026-06-18-profile-benchmark-gdp-pdf.md
+- issues/2026-06-18-profile-benchmark-blueprint-bench-2.md
+- issues/2026-06-18-profile-benchmark-biomysterybench-human.md
+- issues/2026-06-18-profile-benchmark-exploitbench-cap.md
+- issues/2026-06-18-profile-benchmark-healthbench-professional.md


### PR DESCRIPTION
* Created blocker issue tickets for benchmarks `gdp-pdf`, `blueprint-bench-2`, `biomysterybench-human`, `exploitbench-cap`, `healthbench-professional` because they were missing from the Anthropic source.
* Wrote journal file.

---
*PR created automatically by Jules for task [1736766381578245051](https://jules.google.com/task/1736766381578245051) started by @GGJJack*