### PR TITLE
docs(journal): add daily report for 2026-06-18

### DIFF
--- a/src/data/journal/2026-06-19-journal.md
+++ b/src/data/journal/2026-06-19-journal.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-19
+agent: journal
+status: completed
+summary: "2026-06-18 데일리 리포트 생성 완료"
+---
+
+## 수행한 작업
+- [x] `src/data/updates/2026-06-18-daily.md` 파일 생성 완료.
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-06-18-daily.md
+++ b/src/data/updates/2026-06-18-daily.md
@@ -1,0 +1,52 @@
+---
+date: 2026-06-18
+type: note
+title: 데일리 리포트 · 2026-06-18
+summary: "Match scores for lfm2-5-8b-a1b, minimax-m3 / Created issue tickets due to unverified sources for gdp-pdf, blueprint-bench-2, biomysterybench-human, exploitbench-cap, healthbench-professional / Qwen 3.6 35B A3B 및 EEVE-Korean-Instruct-10.8B 상세 페이지 작성"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- **Qwen 3.6 35B A3B**: Cohere North Mini Code 블로그 및 Qwen 블로그 상호 참조를 통해 존재 확인.
+  - `id`: qwen-3-6-35b-a3b
+  - `releaseDate`: 2026-06-09
+  - `parameterSize`: 35B (3B active) MoE
+  - `license`: Apache-2.0
+  - `links.official`: https://qwen.ai/blog
+- **LFM2.5-8B-A1B** (`lfm2-5-8b-a1b`):
+  - `contextWindow` ← 128,000 (https://www.liquid.ai/blog/lfm2-5-8b-a1b)
+  - `license` ← Apache-2.0
+- **Mistral Physics AI (Emmi)** (`mistral-physics-ai-emmi`):
+  - `parameterSize` ← 12B (https://mistral.ai/news/introducing-physics-ai-at-mistral)
+- **EEVE-Korean-Instruct-10.8B** (`eeve-korean-instruct-10.8b`):
+  - `contextWindow` ← 4096 (https://huggingface.co/yanolja/EEVE-Korean-Instruct-10.8B-v1.0)
+  - `links.official` / `links.paper` 추가.
+- Anthropic Fable 5 및 Mythos 5에 대한 미국 정부의 수출 통제 지침(2026-06-12) 확인.
+- Mistral AI Now Summit 2026(2026-05-28) 관련 신규 기능(Vibe, Search Toolkit) 확인.
+- 일부 모델(Sakana Fugu Ultra, HCX-007 등)의 가격 정보는 공식적인 토큰당 가격(1M tokens 기준)이 불분명하여 `null` 유지.
+
+### 벤치마크 (collect-benchmark)
+- [x] Added `if-bench` 56.47, `math` 88.76, `aime-2025` 42.53, `tau-bench-telecom` 88.07 for `lfm2-5-8b-a1b` ← https://www.liquid.ai/blog/lfm2-5-8b-a1b
+- [x] Added `swe-bench-pro` 59.0, `terminal-bench-2-1` 66.0, `mcp-atlas` 74.2 for `minimax-m3` ← https://www.minimaxi.com/blog/minimax-m3
+
+## 상세 페이지 작성 (profile)
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-gdp-pdf.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-blueprint-bench-2.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-biomysterybench-human.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-exploitbench-cap.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] Create issue ticket `src/data/issues/2026-06-18-profile-benchmark-healthbench-professional.md` due to unverified source ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 10:45 **야놀자 (Yanolja)** 조직 프로파일 생성 ← https://huggingface.co/yanolja
+- 10:50 **EEVE-Korean-Instruct-10.8B** 상세 페이지 작성 (published) ← https://huggingface.co/yanolja/YanoljaNEXT-EEVE-Instruct-10.8B-v1.0
+- 10:55 **Qwen 3.6 35B A3B** 상세 페이지 작성 (draft) ← https://cohere.com/blog/north-mini-code
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 0건
+
+## 미해결 이슈
+- issues/2026-06-18-collect-benchmark-gemini-3-5-live-translate.md
+- issues/2026-06-18-profile-benchmark-gdp-pdf.md
+- issues/2026-06-18-profile-benchmark-blueprint-bench-2.md
+- issues/2026-06-18-profile-benchmark-biomysterybench-human.md
+- issues/2026-06-18-profile-benchmark-exploitbench-cap.md
+- issues/2026-06-18-profile-benchmark-healthbench-professional.md


### PR DESCRIPTION
Added the daily report (`src/data/updates/2026-06-18-daily.md`) for 2026-06-18 summarizing all agent journals, and logged completion in today's journal (`src/data/journal/2026-06-19-journal.md`).

---
*PR created automatically by Jules for task [3308166160738685279](https://jules.google.com/task/3308166160738685279) started by @GGJJack*