### PR TITLE
Reinforce maintenance for June 18, 2026

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -40,3 +40,6 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 
 ## 진행 내역 (2026-06-17)
 - (reinforce): 공식 모델 페이지(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview)를 재조사함. 2026년 4월 30일 업데이트 이후 MMLU, GPQA 등 표준 LLM 벤치마크 데이터는 여전히 공표되지 않음. 해당 모델은 128k 컨텍스트 윈도우를 가진 로보틱스 특화 모델로, 일반 벤치마크 점수 누락은 제품 포지셔닝에 따른 의도적인 것으로 최종 재확인됨.
+
+## 진행 내역 (2026-06-18)
+- (reinforce): 공식 모델 페이지(https://ai.google.dev/gemini-api/docs/robotics-overview)를 재점검함. 2026년 6월 4일 업데이트된 문서에서도 MMLU, GPQA 등 표준 LLM 벤치마크 데이터는 여전히 제공되지 않음. 해당 모델은 공간 지능 및 로봇 제어에 특화된 모델로, 일반 벤치마크 점수 누락은 제품의 특수 목적에 따른 의도적인 것으로 최종 재확인됨.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -64,3 +64,6 @@ target: llm/multiple
 
 ## 진행 내역 (2026-06-17)
 - (reinforce): NCP CLOVA Studio, 01.AI, Baichuan AI의 공식 홈페이지를 재점검함. HyperCLOVA X 모델 및 Yi-Large, Baichuan-4의 공식 API 가격은 여전히 '상담 필요' 또는 비공개 상태임. 엔터프라이즈 전용 모델의 특성상 일반 사용자 대상의 공개 가격표 업데이트는 단기간 내에 이루어질 가능성이 낮다고 판단되어 정기 모니터링 체제를 유지함.
+
+## 진행 내역 (2026-06-18)
+- (reinforce): NCP CLOVA Studio, 01.AI, Baichuan AI의 공식 홈페이지를 재점검함. HyperCLOVA X(HCX-007, 005, DASH-002) 및 Yi-Large, Baichuan-4의 공식 API 가격은 여전히 '상담 필요' 또는 비공개 상태임. 엔터프라이즈 전용 모델의 특성상 일반 공개 가격표 업데이트는 단기간 내에 이루어질 가능성이 낮다고 판단되어 정기 모니터링 체제를 유지함.

--- a/src/data/issues/2026-05-07-collect-llm-metadata-missing.md
+++ b/src/data/issues/2026-05-07-collect-llm-metadata-missing.md
@@ -31,3 +31,6 @@ target: llm/multiple
 - `gpt-5-5-instant` ($0.1/$0.4) 및 `alphaevolve` ($2/$12) 가격 정보는 최신 릴리스 기반으로 이미 반영되어 있음을 확인함.
 - `sakana-fugu-ultra/mini`의 벤치마크 점수를 공식 블로그(https://sakana.ai/fugu-beta/)를 통해 확인함. 가격 정보는 베타 단계로 공개되지 않음.
 - 주요 메타데이터가 보강되었으나 `hyperclova-x` 가격 정보가 여전히 누락되어 있으므로 blocker로 격상하여 관리함.
+
+## 진행 내역 (2026-06-18)
+- (reinforce): HyperCLOVA X, Yi-Large, Baichuan-4 관련 가격 정보 부재 상황을 재확인함. Sakana AI Fugu 시리즈 등 베타 단계 모델들의 공식 가격 정보 또한 여전히 공개되지 않음. 주요 엔터프라이즈 및 베타 모델들에 대한 정기 모니터링을 지속함.

--- a/src/data/journal/2026-06-18-reinforce.md
+++ b/src/data/journal/2026-06-18-reinforce.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-18
+agent: reinforce
+status: completed
+summary: "Re-verified Gemini Robotics-ER 1.6 benchmarks and enterprise model pricing (NCP, 01.AI, Baichuan)."
+---
+
+## Todo
+- [x] Investigate Gemini Robotics-ER 1.6 benchmarks (2026-05-05)
+- [x] Investigate HyperCLOVA X, Yi-Large, Baichuan-4 pricing/metadata (2026-05-06, 2026-05-07)
+
+## 조사 내역
+- 10:15 Gemini Robotics-ER 1.6 공식 문서 재확인. 2026-06-04 업데이트되었으나 여전히 MMLU/GPQA 등 표준 벤치마크 없음. ← https://ai.google.dev/gemini-api/docs/robotics-overview
+- 10:25 HyperCLOVA X 요금 페이지 재확인. 여전히 '상담 필요'로 구체적 단가 비공개. ← https://www.ncloud.com/product/ai/clovaStudio
+- 10:30 01.AI (Yi-Large) 및 Baichuan-4 공식 사이트 확인. 공개된 신규 가격 정보 없음. ← https://platform.lingyiwanwu.com/docs
+
+## 수행한 작업
+- [x] src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md 진행 내역 업데이트 ← https://ai.google.dev/gemini-api/docs/robotics-overview
+- [x] src/data/issues/2026-05-06-collect-llm-pricing-missing.md 진행 내역 업데이트 ← https://www.ncloud.com/product/ai/clovaStudio
+- [x] src/data/issues/2026-05-07-collect-llm-metadata-missing.md 진행 내역 업데이트 ← https://platform.lingyiwanwu.com/docs
+
+## 판단 / 고민
+- Gemini Robotics-ER 1.6의 경우 표준 LLM 벤치마크 누락이 의도적인 것으로 보임. 향후 로보틱스 특화 벤치마크 도입 시 재검토 필요.
+- 엔터프라이즈 전용 모델(HCX, Yi-Large 등)의 가격은 일반 공개 가능성이 낮으므로 정기적인 상태 확인 수준에서 유지.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Updated the oldest pending issues (2026-05-05, 2026-05-06, 2026-05-07) regarding Gemini Robotics benchmarks and enterprise pricing for HyperCLOVA X, Yi-Large, and Baichuan-4. Re-verified official documentation and community reports, finding no new public data. Logged all activities in src/data/journal/2026-06-18-reinforce.md.

Fixes #529

---
*PR created automatically by Jules for task [5001812759790336126](https://jules.google.com/task/5001812759790336126) started by @GGJJack*