### PR TITLE
profile-benchmark: handle missing benchmarks in source

### DIFF
--- a/src/data/issues/2026-06-19-profile-benchmark-biomysterybench-human.md
+++ b/src/data/issues/2026-06-19-profile-benchmark-biomysterybench-human.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-19
+agent: profile-benchmark
+severity: blocker
+target: llm/biomysterybench-human
+---
+
+biomysterybench-human 벤치마크의 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다. (소스 매핑 오류 또는 환각으로 추정됨)
+상세 페이지를 생성하지 않았습니다.

--- a/src/data/issues/2026-06-19-profile-benchmark-blueprint-bench-2.md
+++ b/src/data/issues/2026-06-19-profile-benchmark-blueprint-bench-2.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-19
+agent: profile-benchmark
+severity: blocker
+target: llm/blueprint-bench-2
+---
+
+blueprint-bench-2 벤치마크의 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다. (소스 매핑 오류 또는 환각으로 추정됨)
+상세 페이지를 생성하지 않았습니다.

--- a/src/data/issues/2026-06-19-profile-benchmark-exploitbench-cap.md
+++ b/src/data/issues/2026-06-19-profile-benchmark-exploitbench-cap.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-19
+agent: profile-benchmark
+severity: blocker
+target: llm/exploitbench-cap
+---
+
+exploitbench-cap 벤치마크의 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다. (소스 매핑 오류 또는 환각으로 추정됨)
+상세 페이지를 생성하지 않았습니다.

--- a/src/data/issues/2026-06-19-profile-benchmark-gdp-pdf.md
+++ b/src/data/issues/2026-06-19-profile-benchmark-gdp-pdf.md
@@ -1,0 +1,9 @@
+---
+created: 2026-06-19
+agent: profile-benchmark
+severity: blocker
+target: llm/gdp-pdf
+---
+
+gdp-pdf 벤치마크의 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 해당 벤치마크에 대한 언급을 찾을 수 없습니다. (소스 매핑 오류 또는 환각으로 추정됨)
+상세 페이지를 생성하지 않았습니다.

--- a/src/data/journal/2026-06-19-profile-benchmark.md
+++ b/src/data/journal/2026-06-19-profile-benchmark.md
@@ -1,0 +1,10 @@
+---
+date: 2026-06-19
+agent: profile-benchmark
+status: completed
+summary: "gdp-pdf, blueprint-bench-2, biomysterybench-human, exploitbench-cap 벤치마크 소스 확인 실패로 이슈 티켓 생성"
+---
+
+gdp-pdf, blueprint-bench-2, biomysterybench-human, exploitbench-cap의 소스 URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) 에서 해당 벤치마크를 확인할 수 없습니다.
+
+소스에 명시되어 있지 않음을 확인하여 상세 페이지를 생성하지 않고 각각에 대해 이슈 티켓을 생성합니다.


### PR DESCRIPTION
Added issue tickets for gdp-pdf, blueprint-bench-2, biomysterybench-human, and exploitbench-cap due to unverified source URLs, along with the daily journal.

---
*PR created automatically by Jules for task [16762730652146109703](https://jules.google.com/task/16762730652146109703) started by @GGJJack*