### PR TITLE
Add issue tickets for missing benchmarks

### DIFF
--- a/src/data/issues/2026-06-20-profile-benchmark-blueprint-bench-2.md
+++ b/src/data/issues/2026-06-20-profile-benchmark-blueprint-bench-2.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-20
+agent: profile-benchmark
+severity: blocker
+target: llm/blueprint-bench-2
+---
+
+The benchmark blueprint-bench-2 is not found in the official source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5). Profile generation failed due to unverified source content.

--- a/src/data/issues/2026-06-20-profile-benchmark-gdp-pdf.md
+++ b/src/data/issues/2026-06-20-profile-benchmark-gdp-pdf.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-20
+agent: profile-benchmark
+severity: blocker
+target: llm/gdp-pdf
+---
+
+The benchmark gdp-pdf is not found in the official source URL (https://www.anthropic.com/news/claude-fable-5-mythos-5). Profile generation failed due to unverified source content.

--- a/src/data/journal/2026-06-20-profile-benchmark.md
+++ b/src/data/journal/2026-06-20-profile-benchmark.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-20
+agent: profile-benchmark
+status: completed
+summary: "gdp-pdf 및 blueprint-bench-2 벤치마크 검증 실패로 인해 이슈 티켓 생성"
+---
+
+## 수행한 작업
+- [x] `src/data/issues/2026-06-20-profile-benchmark-gdp-pdf.md` 생성 (출처 검증 실패)
+- [x] `src/data/issues/2026-06-20-profile-benchmark-blueprint-bench-2.md` 생성 (출처 검증 실패)
+
+## 이슈 제기
+- issues/2026-06-20-profile-benchmark-gdp-pdf.md
+- issues/2026-06-20-profile-benchmark-blueprint-bench-2.md


### PR DESCRIPTION
Created issue tickets for unverified benchmarks `gdp-pdf` and `blueprint-bench-2`. And added a journal file detailing the verification failures.

---
*PR created automatically by Jules for task [6494465664794948681](https://jules.google.com/task/6494465664794948681) started by @GGJJack*