### PR TITLE
Collect LLM Benchmark scores for vibethinker-3b

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -800,6 +800,34 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "ifeval",
+      "name": "IFEval",
+      "nameKo": "IFEval (명령어 준수 평가)",
+      "category": "instruction",
+      "description": "IFEval은 언어 모델이 주어진 복잡한 제약 조건과 지시사항을 얼마나 정확히 따르는지 검증하기 위한 벤치마크입니다.",
+      "source": "https://arxiv.org/abs/2311.07911",
+      "unit": "점",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "hmmt-25",
+      "name": "HMMT 25",
+      "nameKo": "HMMT 25",
+      "category": "math",
+      "description": "HMMT (Harvard-MIT Mathematics Tournament) 2025 수학 경시대회 문제를 활용한 수학 추론 평가.",
+      "source": "https://www.hmmt.org/",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -2840,6 +2868,32 @@
         "date": "2026-06-01",
         "source": "official",
         "url": "https://www.minimaxi.com/blog/minimax-m3"
+      }
+    },
+    "vibethinker-3b": {
+      "aime-2026": {
+        "value": 94.3,
+        "date": "2026-06-15",
+        "source": "official",
+        "url": "https://arxiv.org/abs/2606.16140"
+      },
+      "livecodebench-v6": {
+        "value": 80.2,
+        "date": "2026-06-15",
+        "source": "official",
+        "url": "https://arxiv.org/abs/2606.16140"
+      },
+      "ifeval": {
+        "value": 93.4,
+        "date": "2026-06-15",
+        "source": "official",
+        "url": "https://arxiv.org/abs/2606.16140"
+      },
+      "hmmt-25": {
+        "value": 89.3,
+        "date": "2026-06-15",
+        "source": "official",
+        "url": "https://arxiv.org/abs/2606.16140"
       }
     }
   }

--- a/src/data/issues/2026-06-21-collect-benchmark-glm-5-turbo.md
+++ b/src/data/issues/2026-06-21-collect-benchmark-glm-5-turbo.md
@@ -1,0 +1,16 @@
+---
+created: 2026-06-21
+agent: collect-benchmark
+severity: major
+target: llm/glm-5-turbo
+---
+
+## 상황
+신규 모델 `glm-5-turbo`의 벤치마크 점수 수집을 위해 공식 출처(Hugging Face 페이지)에 접근을 시도했으나 권한 문제로 접근 불가(401/403)함.
+재현 URL: https://huggingface.co/THUDM/glm-5-turbo
+
+## 시도한 것
+Hugging Face 모델 페이지 `https://huggingface.co/THUDM/glm-5-turbo` 웹페이지 접근 시도.
+
+## 요청
+접근 권한이 해결된 이후, 해당 페이지 또는 다른 공식 출처를 통해 `glm-5-turbo`의 벤치마크 점수를 확인하고 수집할 것.

--- a/src/data/issues/2026-06-21-collect-benchmark-glm-5v-turbo.md
+++ b/src/data/issues/2026-06-21-collect-benchmark-glm-5v-turbo.md
@@ -1,0 +1,16 @@
+---
+created: 2026-06-21
+agent: collect-benchmark
+severity: major
+target: llm/glm-5v-turbo
+---
+
+## 상황
+신규 모델 `glm-5v-turbo`의 벤치마크 점수 수집을 위해 공식 출처(Hugging Face 페이지)에 접근을 시도했으나 권한 문제로 접근 불가(401/403)함.
+재현 URL: https://huggingface.co/THUDM/glm-5v-turbo
+
+## 시도한 것
+Hugging Face 모델 페이지 `https://huggingface.co/THUDM/glm-5v-turbo` 웹페이지 접근 시도.
+
+## 요청
+접근 권한이 해결된 이후, 해당 페이지 또는 다른 공식 출처를 통해 `glm-5v-turbo`의 벤치마크 점수를 확인하고 수집할 것.

--- a/src/data/journal/2026-06-21-collect-benchmark.md
+++ b/src/data/journal/2026-06-21-collect-benchmark.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-21
+agent: collect-benchmark
+status: completed
+summary: "VibeThinker-3B 모델의 AIME 2026, LiveCodeBench v6, IFEval, HMMT 25 점수 등록 완료. glm 모델들은 URL 접근 제한으로 이슈 등록."
+---
+
+## Todo
+- [x] 신규 LLM 모델(VibeThinker-3B, GLM-5-Turbo 등)의 벤치마크 점수 확인 및 등록
+
+## 조사 내역
+- 01:40 `VibeThinker-3B` 점수 확인. AIME26(94.3), LiveCodeBench v6(80.2), IFEval(93.4), HMMT25(89.3) 점수 확인됨 ← https://arxiv.org/abs/2606.16140
+- 01:42 `glm-5-turbo`, `glm-5v-turbo` 정보 확인 시도 (Hugging Face). 접근 불가(401/403)로 인해 내용 확인 실패 ← https://huggingface.co/THUDM/glm-5-turbo, https://huggingface.co/THUDM/glm-5v-turbo
+
+## 수행한 작업
+- [x] 신규 벤치마크 `ifeval`, `hmmt-25` 정의 등록 ← https://arxiv.org/abs/2606.16140
+- [x] `vibethinker-3b`의 AIME 2026 점수(94.3) 등록 ← https://arxiv.org/abs/2606.16140
+- [x] `vibethinker-3b`의 LiveCodeBench v6 점수(80.2) 등록 ← https://arxiv.org/abs/2606.16140
+- [x] `vibethinker-3b`의 IFEval 점수(93.4) 등록 ← https://arxiv.org/abs/2606.16140
+- [x] `vibethinker-3b`의 HMMT 25 점수(89.3) 등록 ← https://arxiv.org/abs/2606.16140
+
+## 판단 / 고민
+- GLM-5-Turbo 등은 HF 모델 페이지 접근 제한으로 공식 정보를 확인할 수 없음. 출처 절대 규칙(§2)에 따라 추측/다른 모델 출처 사용을 금지하므로 이슈 티켓으로 이관.
+
+## 이슈 제기
+- issues/2026-06-21-collect-benchmark-glm-5-turbo.md
+- issues/2026-06-21-collect-benchmark-glm-5v-turbo.md


### PR DESCRIPTION
- Registered new benchmarks `ifeval` and `hmmt-25` based on VibeThinker-3B data.
- Added benchmark scores for `vibethinker-3b` corresponding to `AIME 2026`, `LiveCodeBench v6`, `IFEval`, and `HMMT 25` sourced from arXiv.
- Tracked journal for agent execution.
- Created issues `2026-06-21-collect-benchmark-glm-5-turbo.md` and `2026-06-21-collect-benchmark-glm-5v-turbo.md` due to Hugging Face models showing 401/403 access issues.

---
*PR created automatically by Jules for task [7882188132252840079](https://jules.google.com/task/7882188132252840079) started by @GGJJack*