### PR TITLE
feat: Add NanoBEIR and MKQA-11 benchmarks and match scores for LFM2.5 models

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -828,6 +828,34 @@
         100
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "nanobeir",
+      "name": "NanoBEIR Multilingual Extended (NDCG@10)",
+      "nameKo": "NanoBEIR 다국어 확장 (NDCG@10)",
+      "category": "knowledge",
+      "description": "NanoBEIR multilingual dataset for retrieval performance evaluation.",
+      "source": "https://www.liquid.ai/blog/lfm2-5-retrievers",
+      "unit": "NDCG@10",
+      "scoreRange": [
+        0,
+        1
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "mkqa-11",
+      "name": "MKQA-11 (Recall@20)",
+      "nameKo": "MKQA-11 (Recall@20)",
+      "category": "knowledge",
+      "description": "Cross-lingual open-domain QA dataset.",
+      "source": "https://www.liquid.ai/blog/lfm2-5-retrievers",
+      "unit": "Recall@20",
+      "scoreRange": [
+        0,
+        1
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -2894,6 +2922,34 @@
         "date": "2026-06-15",
         "source": "official",
         "url": "https://arxiv.org/abs/2606.16140"
+      }
+    },
+    "lfm2-5-colbert-350m": {
+      "nanobeir": {
+        "value": 0.605,
+        "date": "2026-06-18",
+        "source": "official",
+        "url": "https://www.liquid.ai/blog/lfm2-5-retrievers"
+      },
+      "mkqa-11": {
+        "value": 0.694,
+        "date": "2026-06-18",
+        "source": "official",
+        "url": "https://www.liquid.ai/blog/lfm2-5-retrievers"
+      }
+    },
+    "lfm2-5-embedding-350m": {
+      "nanobeir": {
+        "value": 0.577,
+        "date": "2026-06-18",
+        "source": "official",
+        "url": "https://www.liquid.ai/blog/lfm2-5-retrievers"
+      },
+      "mkqa-11": {
+        "value": 0.691,
+        "date": "2026-06-18",
+        "source": "official",
+        "url": "https://www.liquid.ai/blog/lfm2-5-retrievers"
       }
     }
   }

--- a/src/data/journal/2026-06-22-collect-benchmark.md
+++ b/src/data/journal/2026-06-22-collect-benchmark.md
@@ -1,0 +1,25 @@
+---
+date: 2026-06-22
+agent: collect-benchmark
+status: completed
+summary: "신규 벤치마크 NanoBEIR, MKQA-11 등록 및 lfm2-5 모델 점수 매칭 완료"
+---
+
+## Todo
+- [x] 신규 LLM 모델의 벤치마크 점수 확인 및 등록
+
+## 조사 내역
+- 01:40 `lfm2-5-embedding-350m`, `lfm2-5-colbert-350m` 점수 확인. NanoBEIR(0.577, 0.605), MKQA-11(0.691, 0.694) 확인됨 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+
+## 수행한 작업
+- [x] 신규 벤치마크 `nanobeir`, `mkqa-11` 정의 등록 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+- [x] `lfm2-5-embedding-350m`의 NanoBEIR 점수(0.577) 등록 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+- [x] `lfm2-5-colbert-350m`의 NanoBEIR 점수(0.605) 등록 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+- [x] `lfm2-5-embedding-350m`의 MKQA-11 점수(0.691) 등록 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+- [x] `lfm2-5-colbert-350m`의 MKQA-11 점수(0.694) 등록 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+
+## 판단 / 고민
+- (없음)
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Adds `nanobeir` and `mkqa-11` to the LLM benchmarks and maps scores for `lfm2-5-embedding-350m` and `lfm2-5-colbert-350m` based on the official Liquid AI blog post. Also creates the journal for 2026-06-22-collect-benchmark task.

---
*PR created automatically by Jules for task [10371017684215284422](https://jules.google.com/task/10371017684215284422) started by @GGJJack*