### PR TITLE
Create profiles for hmmt-25, nanobeir, mkqa-11

### DIFF
--- a/src/content/benchmarks/hmmt-25.md
+++ b/src/content/benchmarks/hmmt-25.md
@@ -1,0 +1,18 @@
+---
+benchmarkId: hmmt-25
+domain: llm
+status: draft
+updated: 2026-06-22
+sources:
+  - https://www.hmmt.org/
+highlights:
+  - "HMMT (Harvard-MIT Mathematics Tournament) 2025 수학 경시대회 문제"
+---
+
+# HMMT 25
+
+## 개요
+HMMT(Harvard-MIT Mathematics Tournament) 2025 수학 경시대회 문제를 활용한 수학 추론 평가입니다.
+
+## 평가 방법
+수학 경시대회 문제를 바탕으로 모델의 수학적 추론 능력을 평가합니다.

--- a/src/content/benchmarks/mkqa-11.md
+++ b/src/content/benchmarks/mkqa-11.md
@@ -1,0 +1,18 @@
+---
+benchmarkId: mkqa-11
+domain: llm
+status: draft
+updated: 2026-06-22
+sources:
+  - https://www.liquid.ai/blog/lfm2-5-retrievers
+highlights:
+  - "Cross-lingual open-domain QA dataset"
+---
+
+# MKQA-11 (Recall@20)
+
+## 개요
+MKQA-11은 언어 간 경계를 넘나드는 오픈 도메인 질문 답변(QA)을 평가하기 위한 데이터셋입니다.
+
+## 평가 방법
+언어 간의 정보 검색 및 답변 추출 능력을 Recall@20 지표를 통해 측정합니다.

--- a/src/content/benchmarks/nanobeir.md
+++ b/src/content/benchmarks/nanobeir.md
@@ -1,0 +1,18 @@
+---
+benchmarkId: nanobeir
+domain: llm
+status: draft
+updated: 2026-06-22
+sources:
+  - https://www.liquid.ai/blog/lfm2-5-retrievers
+highlights:
+  - "NanoBEIR Multilingual Extended"
+---
+
+# NanoBEIR Multilingual Extended (NDCG@10)
+
+## 개요
+NanoBEIR 다국어 확장은 정보 검색 성능을 다국어 환경에서 평가하기 위한 데이터셋입니다.
+
+## 평가 방법
+다양한 언어 환경에서 정보 검색 성능을 평가합니다.

--- a/src/data/issues/2026-06-22-profile-benchmark-hmmt-25-org.md
+++ b/src/data/issues/2026-06-22-profile-benchmark-hmmt-25-org.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-22
+agent: profile-benchmark
+severity: minor
+target: llm/hmmt-25
+---
+
+기관 상세 조사 필요

--- a/src/data/issues/2026-06-22-profile-benchmark-mkqa-11-org.md
+++ b/src/data/issues/2026-06-22-profile-benchmark-mkqa-11-org.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-22
+agent: profile-benchmark
+severity: minor
+target: llm/mkqa-11
+---
+
+기관 상세 조사 필요

--- a/src/data/issues/2026-06-22-profile-benchmark-nanobeir-org.md
+++ b/src/data/issues/2026-06-22-profile-benchmark-nanobeir-org.md
@@ -1,0 +1,8 @@
+---
+created: 2026-06-22
+agent: profile-benchmark
+severity: minor
+target: llm/nanobeir
+---
+
+기관 상세 조사 필요

--- a/src/data/journal/2026-06-22-profile-benchmark.md
+++ b/src/data/journal/2026-06-22-profile-benchmark.md
@@ -1,0 +1,29 @@
+---
+date: 2026-06-22
+agent: profile-benchmark
+status: completed
+summary: "신규 벤치마크(hmmt-25, nanobeir, mkqa-11) 상세 페이지 작성 및 기관 ID 부재 이슈 생성"
+---
+
+## Todo
+- [x] hmmt-25 벤치마크 상세 페이지 작성
+- [x] nanobeir 벤치마크 상세 페이지 작성
+- [x] mkqa-11 벤치마크 상세 페이지 작성
+- [x] 기관 ID 부재 이슈 발행
+
+## 조사 내역
+- 02:30 hmmt-25 조사 완료 ← https://www.hmmt.org/
+- 02:30 nanobeir, mkqa-11 조사 완료 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+
+## 수행한 작업
+- [x] `src/content/benchmarks/hmmt-25.md` 작성 ← https://www.hmmt.org/
+- [x] `src/content/benchmarks/nanobeir.md` 작성 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+- [x] `src/content/benchmarks/mkqa-11.md` 작성 ← https://www.liquid.ai/blog/lfm2-5-retrievers
+
+## 판단 / 고민
+- 각 벤치마크의 관련 기관 ID가 누락되어 있어 임시로 기관 관련 이슈를 제기하였습니다.
+
+## 이슈 제기
+- issues/2026-06-22-profile-benchmark-hmmt-25-org.md
+- issues/2026-06-22-profile-benchmark-nanobeir-org.md
+- issues/2026-06-22-profile-benchmark-mkqa-11-org.md


### PR DESCRIPTION
Created benchmark detail pages for `hmmt-25`, `nanobeir`, and `mkqa-11` adhering to the required frontmatter schema. As the organization details were missing or unverified, I safely generated tracking issues instead of stubs. Also created the daily journal entry (`2026-06-22-profile-benchmark.md`).

---
*PR created automatically by Jules for task [15050979552428818960](https://jules.google.com/task/15050979552428818960) started by @GGJJack*