### PR TITLE
Reinforce: June 22, 2026 Progress Update

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -52,3 +52,6 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 
 ## 진행 내역 (2026-06-21)
 - (reinforce): 공식 기술 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview, 2026-06-18 업데이트)를 재확인함. Robotics-ER 1.6의 토큰 제한(Input 131k, Output 65k) 등 상세 기술 사양은 지속 업데이트되고 있으나, MMLU, GPQA 등 표준 LLM 벤치마크 점수는 여전히 공개되지 않음. 해당 모델은 로보틱스 특화 모델로서 일반 언어 능력보다 물리 세계에서의 추론 및 제어 성능에 집중하고 있으며, 일반 벤치마크 누락은 제품 포지셔닝에 따른 의도적인 것으로 최종 확인됨. 정기 추적을 유지하되 추가 공개 가능성은 매우 낮음.
+
+## 진행 내역 (2026-06-22)
+- (reinforce): 공식 기술 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview, 2026-04-30 최종 업데이트 확인)를 재점검함. MMLU, GPQA 등 표준 LLM 벤치마크 점수는 여전히 제공되지 않으며, 해당 모델이 로보틱스 특화 VLM임을 고려할 때 일반 벤치마크 점수의 공개 가능성은 매우 낮음. 정기 모니터링 대상으로 유지함.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -76,3 +76,6 @@ target: llm/multiple
 
 ## 진행 내역 (2026-06-21)
 - (reinforce): NCP CLOVA Studio 공식 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio, 2026-06-18 확인)를 재점검함. HCX-007, 005, DASH-002 모델의 가격은 여전히 상담 필요('-')로 표시됨. Yi-Large 및 Baichuan-4 또한 공식 홈페이지에서 공개 가격표를 확인할 수 없으며, 기업 대상 협의 품목으로 유지되고 있음. 주요 엔터프라이즈 모델의 공식 가격 정보 획득이 제한적이므로 정기 모니터링을 지속함.
+
+## 진행 내역 (2026-06-22)
+- (reinforce): NCP CLOVA Studio(https://www.ncloud.com/product/ai/clovaStudio) 및 Yi-Large, Baichuan-4 공식 플랫폼을 재조사함. HyperCLOVA X 모델들의 공식 가격은 여전히 '-' (상담 필요) 상태이며, Yi-Large 및 Baichuan-4 또한 공식적인 공개 가격표 업데이트는 확인되지 않음. 엔터프라이즈 전용 모델의 특성상 공개적인 가격 정보 획득은 계속 제한적일 것으로 예상되어 정기 모니터링을 유지함.

--- a/src/data/journal/2026-06-22-reinforce.md
+++ b/src/data/journal/2026-06-22-reinforce.md
@@ -1,0 +1,25 @@
+---
+date: 2026-06-22
+agent: reinforce
+status: completed
+summary: "최고령 이슈 2건(Robotics-ER 1.6 벤치마크 및 엔터프라이즈 모델 가격) 재조사 및 진행 내역 업데이트"
+---
+
+## Todo
+- [x] 2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md 처리
+- [x] 2026-05-06-collect-llm-pricing-missing.md 처리
+
+## 조사 내역
+- 10:15 Gemini Robotics-ER 1.6 공식 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview) 재확인. 표준 LLM 벤치마크 부재 확인.
+- 10:20 NCP CLOVA Studio 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio) 확인. HCX-007, 005, DASH-002 가격은 여전히 '-' (상담 필요).
+- 10:25 Yi-Large, Baichuan-4 공식 플랫폼 확인. 공개 가격표 업데이트 없음.
+
+## 수행한 작업
+- [x] 2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md 에 진행 내역(2026-06-22) 추가
+- [x] 2026-05-06-collect-llm-pricing-missing.md 에 진행 내역(2026-06-22) 추가
+
+## 판단 / 고민
+- 엔터프라이즈 모델 및 특수 목적 모델(Robotics)의 경우 일반적인 수집 경로로는 정보 획득에 한계가 있음. 정기 모니터링은 유지하되, 상태 변화가 없을 경우 기록 업데이트 위주로 진행함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Processed the two oldest pending issues from the backlog:
1. Gemini Robotics-ER 1.6: Re-verified that standard LLM benchmarks (MMLU, GPQA) are still not provided by Google.
2. Enterprise Pricing: Confirmed that official API pricing for HyperCLOVA X, Yi-Large, and Baichuan-4 remains unlisted or consultation-only.
Updates were documented in the respective issue files and the daily journal.

Fixes #567

---
*PR created automatically by Jules for task [14435702480854420988](https://jules.google.com/task/14435702480854420988) started by @GGJJack*