### PR TITLE
Reinforce Activities 2026-06-23

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -55,3 +55,6 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 
 ## 진행 내역 (2026-06-22)
 - (reinforce): 공식 기술 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview, 2026-04-30 최종 업데이트 확인)를 재점검함. MMLU, GPQA 등 표준 LLM 벤치마크 점수는 여전히 제공되지 않으며, 해당 모델이 로보틱스 특화 VLM임을 고려할 때 일반 벤치마크 점수의 공개 가능성은 매우 낮음. 정기 모니터링 대상으로 유지함.
+
+## 진행 내역 (2026-06-23)
+- (reinforce): 공식 기술 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview)를 재점검함. 2026년 6월 23일 업데이트 기준으로도 MMLU, GPQA 등 표준 LLM 벤치마크 데이터는 여전히 제공되지 않음. 해당 모델은 로보틱스 에이전트 전용 VLM으로서 공간 지능 및 물리적 액션 계획에 최적화되어 있어 일반적인 언어 모델 벤치마크를 적용하지 않는 기조가 지속되고 있음. 정기 모니터링을 유지함.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -79,3 +79,6 @@ target: llm/multiple
 
 ## 진행 내역 (2026-06-22)
 - (reinforce): NCP CLOVA Studio(https://www.ncloud.com/product/ai/clovaStudio) 및 Yi-Large, Baichuan-4 공식 플랫폼을 재조사함. HyperCLOVA X 모델들의 공식 가격은 여전히 '-' (상담 필요) 상태이며, Yi-Large 및 Baichuan-4 또한 공식적인 공개 가격표 업데이트는 확인되지 않음. 엔터프라이즈 전용 모델의 특성상 공개적인 가격 정보 획득은 계속 제한적일 것으로 예상되어 정기 모니터링을 유지함.
+
+## 진행 내역 (2026-06-23)
+- (reinforce): NCP CLOVA Studio 요금 페이지 및 주요 API 제공사(01.AI, Baichuan AI)의 공식 홈페이지를 재점검함. HyperCLOVA X(HCX-007, 005, DASH-002)의 공식 가격은 여전히 '상담 필요'로 표시되어 있으며, Yi-Large와 Baichuan-4 역시 공식적인 공개 가격표의 업데이트가 확인되지 않음. 엔터프라이즈 모델의 특성상 공개된 수치 확보가 어려워 정기 모니터링 체제를 지속함.

--- a/src/data/journal/2026-06-23-reinforce.md
+++ b/src/data/journal/2026-06-23-reinforce.md
@@ -1,0 +1,26 @@
+---
+date: 2026-06-23
+agent: reinforce
+status: completed
+summary: "최고령 이슈 2건(Robotics-ER 1.6 벤치마크 및 엔터프라이즈 모델 가격) 재조사 및 진행 내역 업데이트"
+---
+
+## Todo
+- [x] 2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md 처리
+- [x] 2026-05-06-collect-llm-pricing-missing.md 처리
+
+## 조사 내역
+- 10:30 Gemini Robotics-ER 1.6 공식 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview) 재확인. 2026-06-23 기준 업데이트 내역을 확인했으나 표준 LLM 벤치마크(MMLU, GPQA)는 여전히 제공되지 않음.
+- 10:35 NCP CLOVA Studio 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio) 재점검. HCX-007, 005, DASH-002 모델의 요금은 여전히 '-' (상담 필요)로 표시됨.
+- 10:40 Yi-Large 및 Baichuan-4 공식 홈페이지 조사. 공식 API 가격표의 신규 업데이트 또는 확정 수치 확인 불가.
+
+## 수행한 작업
+- [x] 2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md 에 진행 내역(2026-06-23) 추가
+- [x] 2026-05-06-collect-llm-pricing-missing.md 에 진행 내역(2026-06-23) 추가
+
+## 판단 / 고민
+- Robotics-ER 1.6은 6월 23일자로 문서가 업데이트되었음에도 불구하고 일반 LLM 지표를 공개하지 않는 것으로 보아, 제품 전략상 배제된 것이 확실시됨.
+- 엔터프라이즈 모델들의 가격 비공개 기조가 장기화되고 있으나, 시장 상황 변화에 따른 급격한 공개 가능성을 배제할 수 없으므로 정기 추적을 유지함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Completed the 'reinforce' mission for June 23, 2026. Processed the two oldest pending issues (Gemini Robotics-ER 1.6 benchmarks and enterprise model pricing). Detailed investigation confirms that official benchmarks for the robotics-specific Gemini model remain unpublished, and pricing for the target enterprise models remains on a consultation basis. Updated the issue trackers with June 23 progress and created the daily journal entry. Verified the build integrity.

Fixes #573

---
*PR created automatically by Jules for task [1976084218808124846](https://jules.google.com/task/1976084218808124846) started by @GGJJack*