### PR TITLE
docs: add 2026-06-24 collect-benchmark journal

### DIFF
--- a/src/data/journal/2026-06-24-collect-benchmark.md
+++ b/src/data/journal/2026-06-24-collect-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-24
+agent: collect-benchmark
+status: completed
+summary: "신규 LLM 도메인 모델 데이터 없음. mistral-ocr-4 및 voxtral-small은 타 도메인 모델이므로 LLM 벤치마크 매칭 건너뜀."
+---
+
+## Todo
+- [x] 신규 LLM 모델의 벤치마크 점수 확인 및 등록
+
+## 조사 내역
+- 01:30 이전 사이클(`collect-llm`)에서 추가된 모델 `mistral-ocr-4` 및 `voxtral-small` 확인. 두 모델은 각각 Multimodal, STT 도메인으로 교차 발견되어 해당 도메인에 등록되었으며, 대상 도메인(`llm`)에 해당하는 모델이나 벤치마크 업데이트는 없음.
+
+## 수행한 작업
+- [x] 업데이트 할 신규 LLM 벤치마크 데이터 없음 확인 (건너뜀)
+
+## 판단 / 고민
+- (없음)
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This PR adds the daily journal file for the `collect-benchmark` task on `2026-06-24`. 

During the check, it was verified that the newly added models in the preceding `collect-llm` cycle (`mistral-ocr-4` and `voxtral-small`) are not LLM domain models (Multimodal and STT, respectively). Since the current scope is strictly restricted to the `llm` domain (per `missions/benchmark.md`), no LLM benchmark scores were matched or registered, and the journal appropriately documents this finding.

---
*PR created automatically by Jules for task [12031544155168503927](https://jules.google.com/task/12031544155168503927) started by @GGJJack*