### PR TITLE
Log unverifiable benchmarks in profile-benchmark run

### DIFF
--- a/src/data/issues/2026-06-24-profile-benchmark-biomysterybench-human.md
+++ b/src/data/issues/2026-06-24-profile-benchmark-biomysterybench-human.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-24
+agent: profile-benchmark
+severity: blocker
+target: llm/biomysterybench-human
+---
+
+## 상황
+biomysterybench-human 의 공식 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5) 에서 해당 벤치마크에 대한 언급을 찾을 수 없음.
+
+## 시도한 것
+- 공식 소스 URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) 페이지 내용 검색. "biomysterybench" 키워드 부재.
+
+## 요청
+해당 벤치마크 정보의 정확한 출처 URL 업데이트 필요.

--- a/src/data/issues/2026-06-24-profile-benchmark-exploitbench-cap.md
+++ b/src/data/issues/2026-06-24-profile-benchmark-exploitbench-cap.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-24
+agent: profile-benchmark
+severity: blocker
+target: llm/exploitbench-cap
+---
+
+## 상황
+exploitbench-cap 의 공식 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5) 에서 해당 벤치마크에 대한 언급을 찾을 수 없음.
+
+## 시도한 것
+- 공식 소스 URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) 페이지 내용 검색. "exploitbench" 키워드 부재.
+
+## 요청
+해당 벤치마크 정보의 정확한 출처 URL 업데이트 필요.

--- a/src/data/issues/2026-06-24-profile-benchmark-healthbench-professional.md
+++ b/src/data/issues/2026-06-24-profile-benchmark-healthbench-professional.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-24
+agent: profile-benchmark
+severity: blocker
+target: llm/healthbench-professional
+---
+
+## 상황
+healthbench-professional 의 공식 소스 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5) 에서 해당 벤치마크에 대한 언급을 찾을 수 없음.
+
+## 시도한 것
+- 공식 소스 URL (https://www.anthropic.com/news/claude-fable-5-mythos-5) 페이지 내용 검색. "healthbench" 키워드 부재.
+
+## 요청
+해당 벤치마크 정보의 정확한 출처 URL 업데이트 필요.

--- a/src/data/journal/2026-06-24-profile-benchmark.md
+++ b/src/data/journal/2026-06-24-profile-benchmark.md
@@ -1,0 +1,18 @@
+---
+date: 2026-06-24
+agent: profile-benchmark
+status: completed
+summary: "Unverifiable benchmarks biomysterybench-human, exploitbench-cap, healthbench-professional"
+---
+
+## Todo
+## 조사 내역
+- 17:48 biomysterybench-human 소스 확인 실패 (언급 없음) <- https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 17:48 exploitbench-cap 소스 확인 실패 (언급 없음) <- https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 17:48 healthbench-professional 소스 확인 실패 (언급 없음) <- https://www.anthropic.com/news/claude-fable-5-mythos-5
+## 수행한 작업
+## 판단 / 고민
+## 이슈 제기
+- issues/2026-06-24-profile-benchmark-biomysterybench-human.md
+- issues/2026-06-24-profile-benchmark-exploitbench-cap.md
+- issues/2026-06-24-profile-benchmark-healthbench-professional.md


### PR DESCRIPTION
As part of the daily automated `profile-benchmark` run on 2026-06-24, this submission tracks investigation failures into three benchmarks. The listed official source URL did not contain mentions of the `biomysterybench-human`, `exploitbench-cap`, and `healthbench-professional` benchmarks. Blocker issues have been created for human intervention to update the source URLs. This activity has been recorded in the daily journal file.

---
*PR created automatically by Jules for task [8573844742933476495](https://jules.google.com/task/8573844742933476495) started by @GGJJack*