### PR TITLE
Add model profiles for Qwen3-Embedding and Gemini Robotics-ER

### DIFF
--- a/src/content/models/gemini-robotics-er-1-6.md
+++ b/src/content/models/gemini-robotics-er-1-6.md
@@ -1,0 +1,35 @@
+---
+modelId: gemini-robotics-er-1-6
+domain: llm
+status: published
+updated: 2026-06-24
+sources:
+  - https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview
+  - https://ai.google.dev/gemini-api/docs/robotics-overview
+  - https://deepmind.google/models/gemini-robotics/safety
+features:
+  toolUse: true
+  vision: true
+  audioInput: true
+  computerUse: true
+  thinking: true
+highlights:
+  - "로보틱스 에이전트 기능을 위해 설계된 멀티모달 시각 언어 모델(VLM)"
+  - "물리적 세계에서의 고급 추론 및 공간 인지 능력 제공"
+  - "131,072 토큰의 입력 및 65,536 토큰의 출력 컨텍스트 지원"
+relatedOrganization: google
+---
+
+# Gemini Robotics-ER 1.6 소개
+
+## 개요
+Gemini Robotics-ER 1.6은 Google이 로보틱스 분야에 특화하여 개발한 차세대 시각 언어 모델(Vision-Language Model, VLM)입니다. 이 모델은 Gemini의 에이전틱(Agentic) 능력을 물리적 하드웨어에 결합하여, 로봇이 복잡한 시각 데이터를 해석하고 공간적 추론을 수행하며 자연어 명령을 기반으로 행동 계획을 수립할 수 있도록 지원합니다. 현재 프리뷰 단계로 제공되며, 실제 환경에서의 자율적인 상호작용 성능을 대폭 향상시킨 것이 특징입니다.
+
+## 기술 특징
+Gemini Robotics-ER 1.6은 텍스트, 이미지, 비디오, 오디오를 동시에 처리하는 멀티모달 입력 능력을 갖추고 있습니다. 특히 공간적/시간적 추론 능력이 강화되어 객체의 위치(좌표)와 관계를 파악하고, 시간에 따른 장면의 변화를 이해할 수 있습니다. 131,072 토큰의 입력 한도와 65,536 토큰의 대규모 출력 한도를 제공하여 복잡한 지시사항과 대량의 시각적 맥락을 유지할 수 있습니다. 또한 '생각하기(Thinking)' 기능을 지원하여 counting이나 무게 추정 등 고난도 추론 작업 시 연산 예산을 동적으로 조절할 수 있으며, 코드 실행(Code Execution) 및 도구 호출 기능을 통해 로봇 시스템의 API와 직접 통합됩니다.
+
+## 사용 사례
+이 모델은 물체 감지 및 추적, 궤적(Trajectory) 생성, 다단계 과제 조율(Task Orchestration) 등 다양한 로보틱스 작업에 활용됩니다. 예를 들어, 자연어 명령으로 특정 물체를 찾아 옮기거나, 복잡한 점심 가방 싸기 작업을 단계별로 계획하고 실행하는 데 사용될 수 있습니다. 또한 아날로그 게이지 읽기, 회로 기판의 마킹 식별, 액체 잔량 측정과 같이 높은 정밀도가 필요한 시각적 분석 작업에서도 에이전틱 능력을 발휘하여 이미지 확대/회전 등의 사전 작업을 자율적으로 수행합니다.
+
+## 한계
+Gemini Robotics-ER 1.6은 프리뷰 상태의 모델로, 대기 시간(Latency)이 입력 데이터의 해상도나 추론 설정에 따라 증가할 수 있습니다. 로보틱스 특화 모델인 만큼 표준 LLM 벤치마크 지표(MMLU 등)보다는 물리적 환경에서의 수행 능력이 우선시되어 설계되었습니다. 또한 물리적 로봇을 제어할 때 발생할 수 있는 안전 사고를 방지하기 위해 인간의 감독과 별도의 안전 프레임워크와의 긴밀한 통합이 필수적입니다.

--- a/src/content/models/qwen-3-embedding-0-6b.md
+++ b/src/content/models/qwen-3-embedding-0-6b.md
@@ -1,0 +1,29 @@
+---
+modelId: qwen-3-embedding-0-6b
+domain: llm
+status: published
+updated: 2026-06-24
+sources:
+  - https://qwenlm.github.io/blog/qwen3-embedding/
+  - https://huggingface.co/Qwen/Qwen3-Embedding-0.6B
+  - https://github.com/QwenLM/Qwen3-Embedding
+highlights:
+  - "0.6B 파라미터 규모의 고성능 텍스트 임베딩 모델"
+  - "MTEB 리더보드 상위권 기록 및 뛰어난 다국어 지원 (100개 이상의 언어)"
+  - "32K 컨텍스트 윈도우 및 유연한 벡터 차원 정의(MRL) 지원"
+relatedOrganization: alibaba
+---
+
+# Qwen3-Embedding-0.6B 소개
+
+## 개요
+Qwen3-Embedding-0.6B는 Alibaba Cloud의 Qwen 팀이 2025년 6월 5일에 공개한 Qwen3 파운데이션 모델 기반의 텍스트 임베딩 모델입니다. 이 모델은 텍스트 검색(Retrieval), 의미론적 유사도 계산, RAG(Retrieval-Augmented Generation) 시스템의 핵심 구성 요소로 설계되었으며, 비교적 작은 파라미터 규모에도 불구하고 강력한 성능을 제공합니다.
+
+## 기술 특징
+Qwen3-Embedding 시리즈는 이중 인코더(Dual-encoder) 아키텍처를 채택하고 있으며, LoRA 미세 조정을 통해 베이스 모델인 Qwen3의 텍스트 이해 능력을 보존 및 강화했습니다. 0.6B 모델은 28개의 레이어로 구성되어 있으며, 최대 32,768 토큰의 긴 컨텍스트를 지원합니다. 특히 임베딩 벡터의 차원을 유연하게 조정할 수 있는 MRL(Matryoshka Representation Learning) 기술을 지원하여, 성능과 저장 공간 사이의 균형을 맞출 수 있습니다. 훈련 과정에서는 대규모 약지도 학습(Weakly supervised training)과 고품질 라벨링 데이터를 활용한 다단계 학습 패러다임을 따랐습니다.
+
+## 사용 사례
+이 모델은 다국어 검색 시스템, 코드 검색, 대규모 문서 분석 및 RAG 워크플로우에 최적화되어 있습니다. 100개 이상의 언어와 다양한 프로그래밍 언어를 지원하여 글로벌 서비스 및 기술 문서 검색에 강점을 가집니다. 또한 사용자 정의 명령(Instruction-aware) 기능을 통해 특정 언어나 시나리오에 맞춰 임베딩 성능을 향상시킬 수 있습니다.
+
+## 한계
+0.6B 모델은 효율성에 초점을 맞춘 모델로, 더 큰 파라미터를 가진 Qwen3-Embedding-8B 등 상위 모델에 비해서는 절대적인 정확도 면에서 차이가 있을 수 있습니다. 따라서 매우 정밀한 재순위화(Reranking)가 필요한 경우에는 Qwen3-Reranker 시리즈와 함께 사용하는 것이 권장됩니다.

--- a/src/data/journal/2026-06-24-profile-model.md
+++ b/src/data/journal/2026-06-24-profile-model.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-24
+agent: profile-model
+status: completed
+summary: "Qwen3-Embedding-0.6B 및 Gemini Robotics-ER 1.6 상세 페이지 작성 완료"
+---
+
+## Todo
+- [x] Qwen3-Embedding-0.6B 상세 페이지 작성
+- [x] Gemini Robotics-ER 1.6 상세 페이지 작성
+
+## 조사 내역
+- 02:05 작업 시작. `src/content/models/` 에 존재하지 않는 최근 등록 모델 및 주요 모델 확인.
+- 02:07 `qwen-3-embedding-0-6b` (2026-06-18 등록) 및 `gemini-robotics-er-1-6` 선정.
+- 02:15 Qwen 공식 블로그(https://qwenlm.github.io/blog/qwen3-embedding/)에서 Qwen3-Embedding-0.6B 사양 확인. MRL 지원, 32K 컨텍스트, Apache-2.0 라이선스 확인.
+- 02:20 Google AI Developers(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview)에서 Gemini Robotics-ER 1.6 사양 확인. 128K/64K 컨텍스트, 에이전틱 VLM 특징 확인.
+
+## 수행한 작업
+- [x] 상세 페이지 작성: `src/content/models/qwen-3-embedding-0-6b.md` (status: published)
+- [x] 상세 페이지 작성: `src/content/models/gemini-robotics-er-1-6.md` (status: published)
+
+## 판단 / 고민
+- `qwen-3-embedding-0-6b`는 임베딩 전용 모델로, 일반 LLM과는 다른 특징을 서술해야 함.
+- `gemini-robotics-er-1-6`는 로보틱스 특화 VLM으로, 최근 reinforce 작업에서 정보가 보강되었으므로 이를 활용.
+- 두 모델 모두 3개 이상의 출처를 확보하여 `published` 상태로 등록함.
+
+## 이슈 제기
+- (없음)

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Created comprehensive markdown profiles for Qwen3-Embedding-0.6B and Gemini Robotics-ER 1.6 in `src/content/models/`. Both profiles include technical characteristics, use cases, and limitations backed by official sources. Verified correct rendering on the frontend.

Fixes #580

---
*PR created automatically by Jules for task [365089261124940510](https://jules.google.com/task/365089261124940510) started by @GGJJack*