### PR TITLE
feat(journal): generate 2026-06-24 daily report and complete journal task

### DIFF
--- a/src/data/journal/2026-06-25-journal.md
+++ b/src/data/journal/2026-06-25-journal.md
@@ -1,0 +1,26 @@
+---
+date: 2026-06-25
+agent: journal
+status: completed
+summary: "2026-06-24 기준 collect-llm, collect-benchmark, profile-model, profile-benchmark 작업 내역을 종합하여 데일리 리포트 발행"
+---
+
+## Todo
+- [x] 전날(2026-06-24) 에이전트 저널 수집 및 요약
+- [x] 데일리 리포트 (`src/data/updates/2026-06-24-daily.md`) 작성
+
+## 조사 내역
+- `src/data/journal/2026-06-24-collect-benchmark.md`
+- `src/data/journal/2026-06-24-collect-llm.md`
+- `src/data/journal/2026-06-24-profile-benchmark.md`
+- `src/data/journal/2026-06-24-profile-model.md`
+- 현재 `src/data/issues/` 내 잔여 이슈 파일 수: 131개
+
+## 수행한 작업
+- [x] 데일리 리포트 작성 (`src/data/updates/2026-06-24-daily.md`)
+
+## 판단 / 고민
+- (없음)
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-06-24-daily.md
+++ b/src/data/updates/2026-06-24-daily.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-24
+type: note
+title: 데일리 리포트 · 2026-06-24
+summary: Mistral OCR 4 가격 보강 및 주요 글로벌/로컬 모델 메타데이터 검증 완료 / Qwen3-Embedding-0.6B 및 Gemini Robotics-ER 1.6 상세 페이지 작성 완료
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- [x] LLM: `mistral-ocr-4` 가격 보강 (`input: 0.004`) ← https://mistral.ai/pricing/
+- [x] Multimodal: `mistral-ocr-4` 가격 보강 (`input: 0.004`) ← https://mistral.ai/pricing/
+- [x] Multimodal: `mistral-ocr-4` (LLM 도메인과 동기화)
+
+### 벤치마크 (collect-benchmark)
+- [x] 업데이트 할 신규 LLM 벤치마크 데이터 없음 확인 (건너뜀)
+
+## 상세 페이지 작성 (profile)
+- [x] 상세 페이지 작성: `src/content/models/qwen-3-embedding-0-6b.md` (status: published)
+- [x] 상세 페이지 작성: `src/content/models/gemini-robotics-er-1-6.md` (status: published)
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 131건
+
+## 미해결 이슈
+- issues/2026-06-24-profile-benchmark-biomysterybench-human.md — biomysterybench-human 출처 불명
+- issues/2026-06-24-profile-benchmark-exploitbench-cap.md — exploitbench-cap 출처 불명
+- issues/2026-06-24-profile-benchmark-healthbench-professional.md — healthbench-professional 출처 불명


### PR DESCRIPTION
This PR generates the daily report (`src/data/updates/2026-06-24-daily.md`) by aggregating task summaries and lists from the `2026-06-24` agent journals (`collect-llm`, `collect-benchmark`, `profile-model`, `profile-benchmark`). It also creates the journal entry for the current execution (`src/data/journal/2026-06-25-journal.md`) marking its status as completed.

---
*PR created automatically by Jules for task [7744283622092654672](https://jules.google.com/task/7744283622092654672) started by @GGJJack*