### PR TITLE
Profile Benchmark: Issue Generation for Unverified Sources

### DIFF
--- a/src/data/issues/2026-06-25-profile-benchmark-biomysterybench-human.md
+++ b/src/data/issues/2026-06-25-profile-benchmark-biomysterybench-human.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-25
+agent: profile-benchmark
+severity: blocker
+target: llm/biomysterybench-human
+---
+
+## 상황
+출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에 해당 벤치마크 내용이 존재하지 않음.
+
+## 시도한 것
+출처 URL 내용 가져와서 검색
+
+## 요청
+출처 확인 필요

--- a/src/data/issues/2026-06-25-profile-benchmark-exploitbench-cap.md
+++ b/src/data/issues/2026-06-25-profile-benchmark-exploitbench-cap.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-25
+agent: profile-benchmark
+severity: blocker
+target: llm/exploitbench-cap
+---
+
+## 상황
+출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에 해당 벤치마크 내용이 존재하지 않음.
+
+## 시도한 것
+출처 URL 내용 가져와서 검색
+
+## 요청
+출처 확인 필요

--- a/src/data/issues/2026-06-25-profile-benchmark-healthbench-professional.md
+++ b/src/data/issues/2026-06-25-profile-benchmark-healthbench-professional.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-25
+agent: profile-benchmark
+severity: blocker
+target: llm/healthbench-professional
+---
+
+## 상황
+출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에 해당 벤치마크 내용이 존재하지 않음.
+
+## 시도한 것
+출처 URL 내용 가져와서 검색
+
+## 요청
+출처 확인 필요

--- a/src/data/journal/2026-06-25-profile-benchmark.md
+++ b/src/data/journal/2026-06-25-profile-benchmark.md
@@ -1,0 +1,22 @@
+---
+date: 2026-06-25
+agent: profile-benchmark
+status: completed
+summary: "biomysterybench-human, exploitbench-cap, healthbench-professional 프로파일 생성을 시도하였으나 출처 URL에 해당 내용이 없어 이슈 제기함"
+---
+
+## Todo
+- biomysterybench-human, exploitbench-cap, healthbench-professional 벤치마크 프로파일 생성 (src/content/benchmarks/)
+
+## 조사 내역
+- 02:30 출처 URL(https://www.anthropic.com/news/claude-fable-5-mythos-5)에서 BioMysteryBench, ExploitBench, HealthBench 검색 시도 ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 수행한 작업
+
+## 판단 / 고민
+- 제공된 출처 URL에 해당 벤치마크 내용이 존재하지 않아 프로파일 생성을 보류하고 이슈 티켓 생성함.
+
+## 이슈 제기
+- issues/2026-06-25-profile-benchmark-biomysterybench-human.md
+- issues/2026-06-25-profile-benchmark-exploitbench-cap.md
+- issues/2026-06-25-profile-benchmark-healthbench-professional.md


### PR DESCRIPTION
- 02:30 scheduled execution of `profile-benchmark`
- Attempted to create profiles for `biomysterybench-human`, `exploitbench-cap`, `healthbench-professional`.
- Verified that the provided source URL (`https://www.anthropic.com/news/claude-fable-5-mythos-5`) did not explicitly contain information for these benchmarks.
- Skipped creating markdown profiles and instead raised appropriate blocker issues (`src/data/issues/2026-06-25-profile-benchmark-*.md`) due to unverified source mapping.
- Logged tasks and issue tickets in daily journal (`src/data/journal/2026-06-25-profile-benchmark.md`).

---
*PR created automatically by Jules for task [13779517370679365616](https://jules.google.com/task/13779517370679365616) started by @GGJJack*