### PR TITLE
collect-benchmark: Log issues for gpt-5-3-codex-spark, mistral-small-3-1, and qwen-image-edit missing benchmark scores

### DIFF
--- a/src/data/issues/2026-06-26-collect-benchmark-gpt-5-3-codex-spark.md
+++ b/src/data/issues/2026-06-26-collect-benchmark-gpt-5-3-codex-spark.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-26
+agent: collect-benchmark
+severity: blocker
+target: llm/gpt-5-3-codex-spark
+---
+
+## 상황 GPT-5.3-Codex-Spark 벤치마크 점수 부족
+공식 발표(https://openai.com/index/openai-broadcom-jalapeno-inference-chip/) 페이지에서 GPT-5.3-Codex-Spark 모델의 벤치마크 점수나 표를 확인할 수 없습니다.
+
+## 시도한 것
+공식 블로그의 HTML을 파싱하고 텍스트를 검색했으나 MMLU, HumanEval 등의 명시적인 수치를 찾지 못했습니다.
+
+## 요청
+해당 모델에 대한 추가적인 공식 출처나 기술 보고서가 공개되면 벤치마크 점수를 등록해주세요.

--- a/src/data/issues/2026-06-26-collect-benchmark-mistral-small-3-1.md
+++ b/src/data/issues/2026-06-26-collect-benchmark-mistral-small-3-1.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-26
+agent: collect-benchmark
+severity: blocker
+target: llm/mistral-small-3-1
+---
+
+## 상황 Mistral Small 3.1 벤치마크 점수 텍스트 누락
+공식 블로그(https://mistral.ai/news/mistral-small-3-1/)에 벤치마크 관련 성능 언급이 있으나(Instruct Performance, Multimodal Instruct Benchmarks 등), 실제 점수 데이터는 이미지나 가져올 수 없는 형태로 되어있어 텍스트로 명확한 점수 수치를 얻지 못했습니다.
+
+## 시도한 것
+공식 블로그 텍스트 추출 및 HTML 테이블 검색을 시도했으나, 텍스트 형태의 점수 표를 찾을 수 없었습니다. Groundedness Rule에 따라 이미지 등에 포함된 점수는 추측하여 등록하지 않았습니다.
+
+## 요청
+추후 공식 텍스트나 허깅페이스 모델 카드 등 다른 공식 출처를 통해 정확한 점수가 확인되면 등록해주세요.

--- a/src/data/issues/2026-06-26-collect-benchmark-qwen-image-edit.md
+++ b/src/data/issues/2026-06-26-collect-benchmark-qwen-image-edit.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-26
+agent: collect-benchmark
+severity: blocker
+target: llm/qwen-image-edit
+---
+
+## 상황 Qwen-Image-Edit 벤치마크 점수 부족
+공식 블로그(https://qwenlm.github.io/blog/qwen-image-edit/)에서 Qwen-Image-Edit 모델이 "SOTA 성능"을 달성했다고 언급하나, 구체적인 벤치마크 점수 표나 명시적인 수치는 제공되지 않았습니다.
+
+## 시도한 것
+해당 블로그 포스트의 내용을 검색하여 HTML 테이블이나 구체적인 수치를 확인하려 하였으나 찾지 못했습니다.
+
+## 요청
+해당 모델의 평가 논문이나 구체적인 점수 데이터가 포함된 공식 출처가 확보되면 벤치마크 점수를 추가해주세요.

--- a/src/data/journal/2026-06-26-collect-benchmark.md
+++ b/src/data/journal/2026-06-26-collect-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-26
+agent: collect-benchmark
+status: completed
+summary: "gpt-5-3-codex-spark, mistral-small-3-1, qwen-image-edit 모델에 대한 벤치마크 점수를 탐색했으나 명시적인 텍스트 수치를 찾지 못해 모두 이슈로 이월함."
+---
+
+## Todo
+- 신규 등록된 LLM의 벤치마크 수치 확인 및 등록 (gpt-5-3-codex-spark, mistral-small-3-1, qwen-image-edit)
+
+## 조사 내역
+- 01:30 OpenAI GPT-5.3-Codex-Spark 블로그 스캔 ← https://openai.com/index/openai-broadcom-jalapeno-inference-chip/
+  - 블로그에서 정확한 벤치마크 수치 추출 실패 (이슈로 이월)
+- 01:35 Mistral Small 3.1 블로그 스캔 ← https://mistral.ai/news/mistral-small-3-1/
+  - 표 데이터가 이미지 등의 형태로 제공되어 텍스트 수치 확인 불가 (이슈로 이월)
+- 01:40 Qwen-Image-Edit 블로그 스캔 ← https://qwenlm.github.io/blog/qwen-image-edit/
+  - 모델 성능 관련 명시적 점수 수치 미확인 (이슈로 이월)
+
+## 수행한 작업
+- [x] 신규 모델 벤치마크 수치 탐색: `gpt-5-3-codex-spark`, `mistral-small-3-1`, `qwen-image-edit`
+
+## 판단 / 고민
+- 각 모델의 공식 출처 웹 페이지를 탐색하였으나 명시적인 벤치마크 점수 데이터를 텍스트로 추출할 수 없었습니다. Groundedness Rule에 따라 이미지나 다른 형태의 데이터로부터 임의의 점수를 추측하지 않고 모두 이슈 티켓으로 생성하였습니다.
+
+## 이슈 제기
+- issues/2026-06-26-collect-benchmark-gpt-5-3-codex-spark.md
+- issues/2026-06-26-collect-benchmark-mistral-small-3-1.md
+- issues/2026-06-26-collect-benchmark-qwen-image-edit.md


### PR DESCRIPTION
- Explored newly added models (`gpt-5-3-codex-spark`, `mistral-small-3-1`, `qwen-image-edit`) from the previous `collect-llm` task.
- Scanned their official source URLs for benchmark performance scores.
- Documented findings that explicit text-based benchmark scores were unavailable (e.g., provided as images or absent entirely).
- Created corresponding issue tickets in `src/data/issues/` per data provenance constraints.
- Generated the completed `src/data/journal/2026-06-26-collect-benchmark.md` journal.

---
*PR created automatically by Jules for task [4908324259272580708](https://jules.google.com/task/4908324259272580708) started by @GGJJack*