### PR TITLE
reinforce: update oldest pending issues (2026-06-26)

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -64,3 +64,6 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 
 ## 진행 내역 (2026-06-25)
 - (reinforce): 공식 기술 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview, 2026-06-23 업데이트 확인)를 재점검함. MMLU, GPQA 등 표준 LLM 벤치마크 데이터는 여전히 제공되지 않으며, 해당 모델은 로보틱스 특화 VLM으로서 일반 언어 벤치마크를 배제하는 기조가 유지되고 있음. 정기 모니터링을 지속함.
+
+## 진행 내역 (2026-06-26)
+- (reinforce): 공식 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview, 2026-06-23 업데이트)를 최종 재확인함. Robotics-ER 1.6의 기술 사양(131k context, agentic capabilities)은 명시되어 있으나, MMLU/GPQA 등 표준 LLM 지표는 여전히 공표되지 않음. 해당 모델은 물리 세계 작용 및 공간 추론에 최적화된 특수 모델로, 일반 벤치마크 누락은 의도적인 제품 포지셔닝으로 판단됨. "사람 에스컬레이션 필요" 상태를 유지하며 정기 모니터링을 계속함.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -88,3 +88,6 @@ target: llm/multiple
 
 ## 진행 내역 (2026-06-25)
 - (reinforce): NCP CLOVA Studio 요금 안내 페이지(https://www.ncloud.com/product/ai/clovaStudio)를 재확인함. HCX-007, 005, DASH-002 의 가격은 여전히 '-' (상담 필요)로 표시됨. Yi-Large 및 Baichuan-4 공식 홈페이지에서도 일반 공개용 가격표는 확인되지 않아 정기 모니터링을 지속함.
+
+## 진행 내역 (2026-06-26)
+- (reinforce): NCP CLOVA Studio 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio) 및 API 가이드(https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3)를 재점검함. HCX-007, 005, DASH-002 의 가격은 여전히 '상담 필요(-)' 상태임. 다만 HCX-005(128k), HCX-DASH-002(32k)의 Context Window 사양은 공식 문서를 통해 재확인함. Yi-Large 및 Baichuan-4 또한 공식적인 공개 가격표 업데이트가 없어 기존 추적 상태를 유지함.

--- a/src/data/journal/2026-06-26-reinforce.md
+++ b/src/data/journal/2026-06-26-reinforce.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-26
+agent: reinforce
+status: completed
+summary: "Addressing oldest issues: Gemini Robotics-ER 1.6 benchmarks and enterprise model pricing."
+---
+
+## Todo
+- [x] Investigate Gemini Robotics-ER 1.6 benchmarks (2026-05-05)
+- [x] Investigate HyperCLOVA X, Yi-Large, Baichuan-4 pricing (2026-05-06)
+
+## 조사 내역
+- 03:00 시작
+- 03:05 Gemini Robotics-ER 1.6 공식 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview) 재검토. MMLU, GPQA 등 표준 벤치마크는 여전히 공표되지 않음.
+- 03:10 NCP CLOVA Studio 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio) 재검토. HCX-007, 005, DASH-002 요금은 여전히 '상담 필요' 상태임.
+- 03:12 NCP API 가이드(https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3)를 통해 HCX-005(128k), HCX-DASH-002(32k) 컨텍스트 윈도우 사양 재확인.
+- 03:15 Yi-Large 및 Baichuan-4 공식 사이트 및 OpenRouter 재검토. 새로운 공개 가격 정보 없음.
+
+## 수행한 작업
+- [x] `src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md` 업데이트 (진행 내역 추가)
+- [x] `src/data/issues/2026-05-06-collect-llm-pricing-missing.md` 업데이트 (진행 내역 추가)
+
+## 판단 / 고민
+- 엔터프라이즈 모델(HyperCLOVA X, Yi-Large, Baichuan-4)의 공식 가격은 일반 공개보다 상담 위주로 운영되는 기조가 고착화된 것으로 보임.
+- Gemini Robotics-ER 1.6은 제품 성격상 일반 LLM 벤치마크를 계속 배제할 것으로 예상되나, 정책에 따라 정기 추적 유지.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Addressing the two oldest pending issues (2026-05-05 and 2026-05-06). Re-verified that standard LLM benchmarks for Gemini Robotics-ER 1.6 and official API pricing for HyperCLOVA X, Yi-Large, and Baichuan-4 are still not publicly available. Confirmed context window sizes for HCX-005 (128k) and HCX-DASH-002 (32k) via official NCP API documentation. All findings have been documented in the respective issue tickets and the daily reinforce journal.

Fixes #600

---
*PR created automatically by Jules for task [15320026960030928972](https://jules.google.com/task/15320026960030928972) started by @GGJJack*