### PR TITLE
chore: compile 2026-06-26 daily report

### DIFF
--- a/src/data/journal/2026-06-27-journal.md
+++ b/src/data/journal/2026-06-27-journal.md
@@ -1,0 +1,25 @@
+---
+date: 2026-06-27
+agent: journal
+status: completed
+summary: "2026-06-26 기준 collect-llm, collect-benchmark, profile-model 작업 내역을 종합하여 데일리 리포트 발행"
+---
+
+## Todo
+- [x] 전날(2026-06-26) 에이전트 저널 수집 및 요약
+- [x] 데일리 리포트 (`src/data/updates/2026-06-26-daily.md`) 작성
+
+## 조사 내역
+- `src/data/journal/2026-06-26-collect-benchmark.md`
+- `src/data/journal/2026-06-26-collect-llm.md`
+- `src/data/journal/2026-06-26-profile-model.md`
+- 현재 `src/data/issues/` 내 잔여 이슈 파일 수: 131개
+
+## 수행한 작업
+- [x] 데일리 리포트 작성 (`src/data/updates/2026-06-26-daily.md`)
+
+## 판단 / 고민
+- (없음)
+
+## 이슈 제기
+- (없음)

--- a/src/data/updates/2026-06-26-daily.md
+++ b/src/data/updates/2026-06-26-daily.md
@@ -1,0 +1,32 @@
+---
+date: 2026-06-26
+type: note
+title: 데일리 리포트 · 2026-06-26
+summary: gpt-5-3-codex-spark, mistral-small-3-1, qwen-image-edit 벤치마크 점수 확인 불가로 이슈 제기 / Rakuten AI 7B, HCX-007, EXAONE 4.5 33B 공식 링크 보강 및 Mistral 최신 모델(OCR 4, Voxtral) 가격 정보 수집 / Rakuten AI 7B Chat 및 GPT-5.3-Codex-Spark 상세 페이지 작성 완료
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- 보강: HCX-007 · links.official 업데이트 및 published 승격 (https://www.ncloud.com/product/ai/clovaStudio)
+- 보강: EXAONE 4.5 33B · links.official 업데이트 (https://www.lgresearch.ai/exaone)
+- 보강: Rakuten AI 7B (Instruct, Chat) · links.official 업데이트 (https://corp.rakuten.co.jp/news/press/2024/0321_01.html)
+- 보강: Mistral OCR 4 · pricing 업데이트 (https://mistral.ai/pricing/)
+- 보강: Voxtral TTS · pricing 업데이트 (https://mistral.ai/pricing/)
+- 보강: Voxtral Mini Transcribe 2, Realtime · pricing 업데이트 (https://mistral.ai/pricing/)
+- 보강: DeepSeek-V4 Preview · highlights 업데이트 (https://www.deepseek.com/)
+
+### 벤치마크 (collect-benchmark)
+- (신규 등록된 LLM의 벤치마크 수치 확인 불가로 이슈 제기)
+
+## 상세 페이지 작성 (profile)
+- models/rakuten-ai-7b-chat · status=published
+- models/gpt-5-3-codex-spark · status=published
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 131건
+
+## 미해결 이슈
+- issues/2026-06-26-collect-benchmark-gpt-5-3-codex-spark.md — GPT-5.3-Codex-Spark 벤치마크 점수 부족
+- issues/2026-06-26-collect-benchmark-mistral-small-3-1.md — Mistral Small 3.1 벤치마크 점수 텍스트 누락
+- issues/2026-06-26-collect-benchmark-qwen-image-edit.md — Qwen-Image-Edit 벤치마크 점수 부족


### PR DESCRIPTION
Generated the daily report for `2026-06-26` by reading the agent journals (`collect-llm`, `collect-benchmark`, `profile-model`) and recorded the journal task's completion status in `2026-06-27-journal.md`. All activities and issue counts were extracted strictly from the journal files without hallucination.

---
*PR created automatically by Jules for task [10622345365708515570](https://jules.google.com/task/10622345365708515570) started by @GGJJack*