### PR TITLE
chore: log no updates for profile-benchmark on 2026-06-27

### DIFF
--- a/src/data/journal/2026-06-27-profile-benchmark.md
+++ b/src/data/journal/2026-06-27-profile-benchmark.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-27
+agent: profile-benchmark
+status: completed
+summary: "모든 벤치마크 도메인(llm, multimodal, image-gen, tts, stt)과 연관 기관에 대해 누락된 프로필 파일이 존재하지 않아 추가 처리 없이 완료함."
+---
+
+## Todo
+- 신규 벤치마크 프로필 작성 및 연관 기관 스텁 생성 대상 탐색
+
+## 조사 내역
+- 02:30 `src/content/benchmarks/` 및 `src/content/organizations/` 조회 결과, 누락된 프로파일 없음
+
+## 수행한 작업
+- (대상 없음)
+
+## 판단 / 고민
+- 모든 벤치마크 및 참조 기관이 이미 `src/content/` 디렉터리에 반영되어 있어 추가 작업 없이 완료로 기록함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
- The daily `profile-benchmark` task executed on 2026-06-27.
- Checked `src/content/benchmarks/` against all 73 known benchmarks across domains (llm, multimodal, image-gen, tts, stt) and verified all have existing markdown profiles.
- Checked `src/content/organizations/` against all referenced organizations in the benchmark profiles and verified all have existing organization stubs.
- Created `2026-06-27-profile-benchmark.md` journal file documenting the completion state with no missing files to process.

---
*PR created automatically by Jules for task [5193079554367454241](https://jules.google.com/task/5193079554367454241) started by @GGJJack*