### PR TITLE
reinforce · 2026-06-27 (Addressing oldest issues)

### DIFF
--- a/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
+++ b/src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md
@@ -67,3 +67,6 @@ Gemini Robotics-ER 1.6 의 벤치마크 점수를 공식 문서 및 커뮤니티
 
 ## 진행 내역 (2026-06-26)
 - (reinforce): 공식 문서(https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-1.6-preview, 2026-06-23 업데이트)를 최종 재확인함. Robotics-ER 1.6의 기술 사양(131k context, agentic capabilities)은 명시되어 있으나, MMLU/GPQA 등 표준 LLM 지표는 여전히 공표되지 않음. 해당 모델은 물리 세계 작용 및 공간 추론에 최적화된 특수 모델로, 일반 벤치마크 누락은 의도적인 제품 포지셔닝으로 판단됨. "사람 에스컬레이션 필요" 상태를 유지하며 정기 모니터링을 계속함.
+
+## 진행 내역 (2026-06-27)
+- (reinforce): Google AI Developers 공식 문서(https://ai.google.dev/gemini-api/docs/robotics-overview)를 재검토하였으나, 여전히 MMLU, GPQA 등 표준 LLM 벤치마크 데이터는 추가되지 않음. 로보틱스 특화 모델로서의 정체성이 확고하여 향후에도 일반 언어 모델 지표 공개 가능성은 매우 낮은 것으로 보임. 정기 추적을 유지함.

--- a/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
+++ b/src/data/issues/2026-05-06-collect-llm-pricing-missing.md
@@ -91,3 +91,6 @@ target: llm/multiple
 
 ## 진행 내역 (2026-06-26)
 - (reinforce): NCP CLOVA Studio 요금 페이지(https://www.ncloud.com/product/ai/clovaStudio) 및 API 가이드(https://api.ncloud-docs.com/docs/clovastudio-chatcompletionsv3)를 재점검함. HCX-007, 005, DASH-002 의 가격은 여전히 '상담 필요(-)' 상태임. 다만 HCX-005(128k), HCX-DASH-002(32k)의 Context Window 사양은 공식 문서를 통해 재확인함. Yi-Large 및 Baichuan-4 또한 공식적인 공개 가격표 업데이트가 없어 기존 추적 상태를 유지함.
+
+## 진행 내역 (2026-06-27)
+- (reinforce): NCP CLOVA Studio 요금 안내 페이지(https://www.ncloud.com/product/ai/clovaStudio)를 재확인한 결과, HyperCLOVA X 계열(HCX-007, 005, DASH-002)의 가격은 여전히 비공개(상담 필요) 상태임. Yi-Large 및 Baichuan-4 또한 공식 홈페이지에서 일반 공개용 가격표는 식별되지 않음. OpenRouter 등 3사 플랫폼 정보를 참고하여 최신성을 유지하되, 공식 가격 확보를 위한 모니터링을 지속함.

--- a/src/data/journal/2026-06-27-reinforce.md
+++ b/src/data/journal/2026-06-27-reinforce.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-27
+agent: reinforce
+status: completed
+summary: "Investigated oldest issues: Gemini Robotics-ER 1.6 benchmarks and enterprise model pricing."
+---
+
+## Todo
+- [x] Investigate Gemini Robotics-ER 1.6 benchmarks (2026-05-05)
+- [x] Investigate HyperCLOVA X, Yi-Large, Baichuan-4 pricing (2026-05-06)
+
+## 조사 내역
+- 03:00 시작
+- 03:05 Gemini Robotics-ER 1.6 공식 문서 및 Robotics 개요 페이지(https://ai.google.dev/gemini-api/docs/robotics-overview) 재검토. MMLU, GPQA 등 표준 LLM 벤치마크는 여전히 공표되지 않음. 모델의 특성상 로봇 제어 및 공간 지능 성능에 집중되어 있음.
+- 03:10 NAVER Cloud NCP CLOVA Studio 요금 안내 페이지(https://www.ncloud.com/product/ai/clovaStudio) 재확인. HCX-007, 005, DASH-002 요금은 여전히 '상담 필요' 상태로 구체적인 단가 테이블이 일반에 공개되지 않음.
+- 03:15 OpenRouter 및 01.AI, Baichuan AI 공식 채널 재조사. Yi-Large 및 Baichuan-4의 공식 API 가격표 변동 없음 (OpenRouter 등 3사 플랫폼 단가 유지).
+
+## 수행한 작업
+- [x] `src/data/issues/2026-05-05-collect-benchmark-gemini-robotics-er-1-6.md` 업데이트 (진행 내역 추가)
+- [x] `src/data/issues/2026-05-06-collect-llm-pricing-missing.md` 업데이트 (진행 내역 추가)
+
+## 판단 / 고민
+- 엔터프라이즈 전용 모델 및 로보틱스 특화 모델의 경우, 일반적인 LLM 벤치마크나 공개 가격표 정책을 따르지 않는 경향이 뚜렷함.
+- 신규 데이터 확보가 어려우나, 정책에 따라 주기적인 모니터링을 수행하고 진행 내역을 기록함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Investigated the oldest pending issues as per the `reinforce` skill procedure. Updated the issue tickets for Gemini Robotics-ER 1.6 benchmarks and enterprise model pricing (HyperCLOVA X, Yi-Large, Baichuan-4) with today's verification results. Standard benchmarks and official public pricing for these models remain unavailable. Logged activities in the daily journal. Verified project build via `bun run build`.

Fixes #609

---
*PR created automatically by Jules for task [10241858257560209167](https://jules.google.com/task/10241858257560209167) started by @GGJJack*