### PR TITLE
collect-benchmark: GPT-5.6 점수 등록 및 이슈 정리 (2026-06-28)

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -856,6 +856,34 @@
         1
       ],
       "higherIsBetter": true
+    },
+    {
+      "id": "frontierbench",
+      "name": "FrontierBench",
+      "nameKo": "프론티어벤치 (FrontierBench)",
+      "category": "coding",
+      "description": "Cognition의 프론티어 코딩 평가(frontier coding eval)",
+      "source": "https://www.anthropic.com/news/claude-fable-5-mythos-5",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
+    },
+    {
+      "id": "vibench",
+      "name": "ViBench",
+      "nameKo": "ViBench (Vibe-coding benchmark)",
+      "category": "coding",
+      "description": "end-to-end vibe-coding benchmark",
+      "source": "https://www.anthropic.com/news/claude-fable-5-mythos-5",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true
     }
   ],
   "scores": {
@@ -2950,6 +2978,30 @@
         "date": "2026-06-18",
         "source": "official",
         "url": "https://www.liquid.ai/blog/lfm2-5-retrievers"
+      }
+    },
+    "gpt-5-6-sol": {
+      "healthbench-professional": {
+        "value": 60.5,
+        "date": "2026-06-26",
+        "source": "official",
+        "url": "https://deploymentsafety.openai.com/gpt-5-6-preview"
+      }
+    },
+    "gpt-5-6-terra": {
+      "healthbench-professional": {
+        "value": 57.7,
+        "date": "2026-06-26",
+        "source": "official",
+        "url": "https://deploymentsafety.openai.com/gpt-5-6-preview"
+      }
+    },
+    "gpt-5-6-luna": {
+      "healthbench-professional": {
+        "value": 55.7,
+        "date": "2026-06-26",
+        "source": "official",
+        "url": "https://deploymentsafety.openai.com/gpt-5-6-preview"
       }
     }
   }

--- a/src/data/issues/2026-06-28-collect-benchmark-claude-scores.md
+++ b/src/data/issues/2026-06-28-collect-benchmark-claude-scores.md
@@ -1,0 +1,14 @@
+---
+created: 2026-06-28
+agent: collect-benchmark
+severity: minor
+target: llm/claude-fable-5
+---
+## 상황
+https://www.anthropic.com/news/claude-fable-5-mythos-5 페이지에 Claude Fable 5가 `FrontierBench`에서 최고 점수, `ViBench`에서 최고 성능을 달성했다는 언급은 있으나, 구체적인 수치(점수 데이터)가 명시되어 있지 않음. ("Claude Fable 5 is the first to break 90% on our core analytics benchmark"라는 표현은 있으나 구체적인 벤치마크 명이 아님)
+
+## 시도한 것
+웹 페치 후 텍스트를 파싱하여 점수를 확인했으나 수치가 제공되지 않음.
+
+## 요청
+정확한 수치나 추가 리더보드 정보를 통한 점수 매칭 필요.

--- a/src/data/issues/2026-06-28-collect-benchmark-grok.md
+++ b/src/data/issues/2026-06-28-collect-benchmark-grok.md
@@ -1,0 +1,14 @@
+---
+created: 2026-06-28
+agent: collect-benchmark
+severity: minor
+target: multimodal/grok-imagine-video-1-5
+---
+## 상황
+https://x.ai/news/grok-imagine-video-1-5 접속 시 Cloudflare 보호 페이지("Attention Required! | Cloudflare")에 의해 차단되어 내용을 가져올 수 없음.
+
+## 시도한 것
+웹 페치를 시도하였으나 403 / Cloudflare 차단으로 인해 벤치마크 정보를 확인할 수 없음.
+
+## 요청
+Cloudflare 우회 혹은 브라우저 환경에서 점수 데이터를 수집하여 보강 필요.

--- a/src/data/issues/2026-06-28-collect-benchmark-mistral-ocr-4.md
+++ b/src/data/issues/2026-06-28-collect-benchmark-mistral-ocr-4.md
@@ -1,0 +1,14 @@
+---
+created: 2026-06-28
+agent: collect-benchmark
+severity: minor
+target: llm/mistral-ocr-4
+---
+## 상황
+https://mistral.ai/news/ocr-4/ 페이지에서 Mistral OCR 4 모델에 대한 벤치마크 점수나 수치를 찾을 수 없음.
+
+## 시도한 것
+페이지 전체 텍스트 및 테이블 구조를 파싱하여 `MMLU`, `GPQA`, `HumanEval` 등 대상 벤치마크 점수를 검색했으나 발견되지 않음.
+
+## 요청
+해당 모델에 대한 벤치마크 정보가 공식 기술 문서나 다른 경로로 공개되어 있는지 추가 확인 필요.

--- a/src/data/issues/2026-06-28-collect-benchmark-openai-preview.md
+++ b/src/data/issues/2026-06-28-collect-benchmark-openai-preview.md
@@ -1,0 +1,14 @@
+---
+created: 2026-06-28
+agent: collect-benchmark
+severity: minor
+target: llm/gpt-5-6-sol
+---
+## 상황
+https://openai.com/index/previewing-gpt-5-6-sol/ 접속 시 HTTP Error 403: Forbidden 발생.
+
+## 시도한 것
+curl 및 python urllib(Mozilla/5.0 User-Agent)로 접근을 시도하였으나 차단됨.
+
+## 요청
+접근 차단 우회 혹은 브라우저 기반 스크래핑 등을 통해 공식 블로그 내용 확인 및 벤치마크 점수 추출 필요.

--- a/src/data/journal/2026-06-28-collect-benchmark.md
+++ b/src/data/journal/2026-06-28-collect-benchmark.md
@@ -1,0 +1,36 @@
+---
+date: 2026-06-28
+agent: collect-benchmark
+status: completed
+summary: "GPT-5.6 시리즈 HealthBench 점수 매칭 및 신규 벤치마크(FrontierBench, ViBench) 정의 등록, 확인 불가 항목 이슈 생성"
+---
+
+## Todo
+- [x] 전일/금일 등록된 신규 LLM 벤치마크 조사
+- [x] GPT-5.6 시리즈 벤치마크 점수 등록
+- [x] 신규 벤치마크 정의 등록
+- [x] 출처 접근 불가 및 점수 누락 건에 대한 이슈 티켓 생성
+
+## 조사 내역
+- 01:40 GPT-5.6 System Card 내 벤치마크 및 HealthBench 점수 확인 ← https://deploymentsafety.openai.com/gpt-5-6-preview
+- 01:42 GPT-5.6 공식 블로그 접근 시도 (403 Forbidden) ← https://openai.com/index/previewing-gpt-5-6-sol/
+- 01:45 Grok 1.5 공식 링크 웹 페치 (Cloudflare 차단) ← https://x.ai/news/grok-imagine-video-1-5
+- 01:47 Mistral OCR 4 공식 링크 내 벤치마크 점수 없음 확인 ← https://mistral.ai/news/ocr-4/
+- 01:50 Claude Fable 5, Mythos 5 공식 링크에서 신규 벤치마크명(FrontierBench, ViBench) 확인 및 구체적 점수 누락 확인 ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 수행한 작업
+- [x] GPT-5.6 Sol의 `healthbench-professional` 점수(60.5) 등록 ← https://deploymentsafety.openai.com/gpt-5-6-preview
+- [x] GPT-5.6 Terra의 `healthbench-professional` 점수(57.7) 등록 ← https://deploymentsafety.openai.com/gpt-5-6-preview
+- [x] GPT-5.6 Luna의 `healthbench-professional` 점수(55.7) 등록 ← https://deploymentsafety.openai.com/gpt-5-6-preview
+- [x] 신규 벤치마크 `frontierbench` 정의 등록 (Cognition's frontier coding eval) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- [x] 신규 벤치마크 `vibench` 정의 등록 (end-to-end vibe-coding benchmark) ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+
+## 판단 / 고민
+- GPT-5.6 System Card의 다른 테이블은 점수 형식이 명확하지 않거나 타 모델과 비교하기 애매한 세부 항목이 많아 가장 명확한 HealthBench Professional 점수만 우선 등록함.
+- Claude 발표문에서 FrontierBench와 ViBench에서 "highest-scoring" 이라는 텍스트를 발견했으나, 점수 수치가 기재되어 있지 않아 점수 매칭은 보류하고 정의만 추가함.
+
+## 이슈 제기
+- issues/2026-06-28-collect-benchmark-openai-preview.md
+- issues/2026-06-28-collect-benchmark-mistral-ocr-4.md
+- issues/2026-06-28-collect-benchmark-claude-scores.md
+- issues/2026-06-28-collect-benchmark-grok.md


### PR DESCRIPTION
- 2026-06-28 KST 기준 collect-benchmark 사이클 수행
- 신규 등록된 LLM(GPT-5.6 Sol, Terra, Luna 등)에 대한 벤치마크 매칭
- OpenAI GPT-5.6 Preview 시스템 카드를 참조하여 HealthBench Professional 점수 등록
- Claude 발표문을 바탕으로 `frontierbench` 및 `vibench` 벤치마크 정의 추가
- 점수를 명확히 찾을 수 없거나(Mistral OCR 4, Claude Fable 5 수치 누락) 접근이 차단된 출처(Grok 1.5, OpenAI 블로그)에 대해서는 `src/data/issues/`에 티켓 생성
- `src/data/journal/2026-06-28-collect-benchmark.md` 생성 완료

---
*PR created automatically by Jules for task [16535975549758603635](https://jules.google.com/task/16535975549758603635) started by @GGJJack*