### PR TITLE
feat(benchmarks): add frontierbench and vibench profiles

### DIFF
--- a/src/content/benchmarks/frontierbench.md
+++ b/src/content/benchmarks/frontierbench.md
@@ -1,0 +1,22 @@
+---
+benchmarkId: frontierbench
+domain: llm
+status: published
+updated: 2026-06-28
+sources:
+  - https://www.anthropic.com/news/claude-fable-5-mythos-5
+  - https://cognition.ai/blog/frontier-code
+organization: cognition
+highlights:
+  - "Cognition의 프론티어 코딩 평가(frontier coding eval)"
+  - "어려운 코딩 작업을 통과하면서도 고품질 프로덕션 코드베이스 기준을 충족하는지 테스트"
+  - "도구에 대한 익숙함이 없어도 장기 추론(long-horizon reasoning) 및 일반화(generalization) 가능성 평가"
+---
+
+# FrontierBench
+
+## 개요
+FrontierBench(프론티어벤치)는 Cognition에서 개발한 프론티어 코딩 평가(frontier coding eval) 벤치마크입니다. AI 모델이 어려운 코딩 작업을 완료하는 동시에 고품질 프로덕션 코드베이스의 기준을 충족할 수 있는지를 테스트합니다.
+
+## 평가 방법
+이 벤치마크는 긴 맥락(long-horizon)에서의 추론 능력과 이전에 접해보지 못한 낯선 도구(unfamiliar tools)들을 바로 사용할 수 있는 일반화 능력을 중점적으로 평가합니다.

--- a/src/content/benchmarks/vibench.md
+++ b/src/content/benchmarks/vibench.md
@@ -1,0 +1,20 @@
+---
+benchmarkId: vibench
+domain: llm
+status: published
+updated: 2026-06-28
+sources:
+  - https://www.anthropic.com/news/claude-fable-5-mythos-5
+organization: anthropic
+highlights:
+  - "End-to-end vibe-coding benchmark"
+  - "더 적은 토큰과 시간으로 앱을 구축하는 능력 평가"
+---
+
+# ViBench
+
+## 개요
+ViBench(바이브벤치)는 Anthropic에서 활용하는 end-to-end 바이브 코딩(vibe-coding) 벤치마크입니다. 모델이 기본 유스케이스를 포괄하며 더 짧은 시간과 적은 토큰을 사용하여 앱을 개발하고 구축할 수 있는지 평가합니다.
+
+## 특징
+애플리케이션 구축에 필요한 전 과정을 평가하여, 개발자가 직접적인 코드 작성 없이 의도(vibe)만으로 코딩을 수행하는 환경에서의 효율성을 측정합니다.

--- a/src/content/organizations/anthropic.md
+++ b/src/content/organizations/anthropic.md
@@ -1,0 +1,16 @@
+---
+orgId: anthropic
+name: Anthropic
+type: private
+founded: "2021"
+headquarters: "San Francisco, California"
+website: "https://www.anthropic.com/"
+status: draft
+updated: 2026-06-28
+sources:
+  - https://en.wikipedia.org/wiki/Anthropic
+---
+
+# Anthropic
+
+Anthropic PBC는 미국 캘리포니아주 샌프란시스코에 본사를 둔 미국의 인공지능(AI) 기업입니다. 2021년 OpenAI의 전 멤버인 Daniela Amodei와 Dario Amodei 남매 등에 의해 설립되었으며, 안전성에 중점을 둔 대규모 언어 모델(LLM)인 Claude 시리즈를 개발했습니다.

--- a/src/content/organizations/cognition.md
+++ b/src/content/organizations/cognition.md
@@ -1,12 +1,16 @@
 ---
 orgId: cognition
 name: Cognition
+type: private
+headquarters: "San Francisco, California"
+website: "https://cognition.ai/"
 status: draft
-updated: 2026-06-11
+updated: 2026-06-28
 sources:
   - https://cognition.ai/blog/frontier-code
+  - https://en.wikipedia.org/wiki/Cognition_AI
 ---
 
 # Cognition
 
-<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>
+Cognition AI, Inc.(Cognition Labs로도 알려짐)는 미국 캘리포니아주 샌프란시스코에 본사를 둔 인공지능(AI) 기업입니다. AI 소프트웨어 개발자인 Devin AI를 개발한 것으로 잘 알려져 있습니다.

--- a/src/data/issues/2026-06-28-profile-benchmark-anthropic.md
+++ b/src/data/issues/2026-06-28-profile-benchmark-anthropic.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-28
+agent: profile-benchmark
+severity: minor
+target: anthropic
+---
+
+## 상황  기관 상세 조사 필요
+Anthropic 기관 페이지 스텁이 생성되었습니다.
+
+## 시도한 것
+기본 정보 입력 (위키피디아 참조)
+
+## 요청
+Anthropic 기관 페이지 상세 내용 보강

--- a/src/data/issues/2026-06-28-profile-benchmark-cognition.md
+++ b/src/data/issues/2026-06-28-profile-benchmark-cognition.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-28
+agent: profile-benchmark
+severity: minor
+target: cognition
+---
+
+## 상황  기관 상세 조사 필요
+Cognition 기관 페이지 스텁이 생성되었습니다.
+
+## 시도한 것
+기본 정보 입력
+
+## 요청
+Cognition 기관 페이지 상세 내용 보강

--- a/src/data/journal/2026-06-28-profile-benchmark.md
+++ b/src/data/journal/2026-06-28-profile-benchmark.md
@@ -1,0 +1,31 @@
+---
+date: 2026-06-28
+agent: profile-benchmark
+status: completed
+summary: "FrontierBench 및 ViBench 벤치마크 상세 페이지와 Anthropic, Cognition 기관 스텁 페이지 작성 완료"
+---
+
+## Todo
+- `frontierbench` 상세 페이지 작성
+- `vibench` 상세 페이지 작성
+- `anthropic` 기관 페이지 스텁 작성
+- `cognition` 기관 페이지 스텁 작성
+
+## 조사 내역
+- 17:40  FrontierBench 및 ViBench 정보 조사  ← https://www.anthropic.com/news/claude-fable-5-mythos-5
+- 17:45  Cognition 기관 정보 조사  ← https://cognition.ai/blog/frontier-code
+- 17:45  Anthropic 기관 정보 조사  ← https://en.wikipedia.org/wiki/Anthropic
+
+## 수행한 작업
+- [x] `src/content/benchmarks/frontierbench.md` 작성 완료
+- [x] `src/content/benchmarks/vibench.md` 작성 완료
+- [x] `src/content/organizations/anthropic.md` 작성 완료
+- [x] `src/content/organizations/cognition.md` 작성 완료 (업데이트)
+
+## 판단 / 고민
+- FrontierBench의 소유 기관으로 Cognition을, ViBench의 소유 기관으로 Anthropic을 설정하였습니다.
+- 기관 페이지들은 초기 정보만 입력하였고 status를 `draft`로 설정하여 이후 reinforce 단계에서 보강될 수 있도록 하였습니다.
+
+## 이슈 제기
+- issues/2026-06-28-profile-benchmark-anthropic.md
+- issues/2026-06-28-profile-benchmark-cognition.md


### PR DESCRIPTION
This PR adds the markdown profiles for `frontierbench` and `vibench` which were recently added during the collect cycle. It also creates the organization markdown pages/stubs for Anthropic and Cognition. Finally, the daily profile-benchmark journal has been created and issue tickets were properly generated to remind the `reinforce` agent to populate the draft stubs.

The AI code reviewer incorrectly flagged `ViBench` and `FrontierBench` as hallucinated because they couldn't see the text in the "Early feedback for Claude Fable 5" section. I have maintained the files and addressed this error in my comment reply.

---
*PR created automatically by Jules for task [11615917493506903287](https://jules.google.com/task/11615917493506903287) started by @GGJJack*