### PR TITLE
Add CoffeeBench profile and Sakana AI stub

### DIFF
--- a/src/content/benchmarks/coffeebench.md
+++ b/src/content/benchmarks/coffeebench.md
@@ -1,0 +1,20 @@
+---
+benchmarkId: "coffeebench"
+domain: "llm"
+status: "draft"
+updated: 2026-06-30
+organization: "sakana-ai"
+sources:
+  - "https://sakana.ai/coffee-bench/"
+highlights:
+  - "멀티에이전트 경제 환경에서의 장기적인 의사결정 및 기업 경영 능력 평가"
+  - "90일간의 커피 공급망 시뮬레이션 기반"
+---
+
+# CoffeeBench
+
+CoffeeBench는 Sakana AI와 유한책임 아즈사 감사법인이 공동으로 개발한, 멀티에이전트 경제 환경 내에서 LLM 에이전트의 장기적인 경영 능력을 평가하기 위한 벤치마크입니다.
+
+커피 산업의 공급망(농가, 로스터리, 소매점)을 모델로 하여, 각 기업이 상호 독립적으로 경영 판단을 내리는 90일간의 시뮬레이션을 통해 순이익을 창출하는 능력을 평가합니다.
+
+단순한 도구 사용 횟수보다 실제 이익에 직결되는 행동(가격 협상, 거래 체결 등)과 타사와의 능동적인 커뮤니케이션 능력을 측정할 수 있습니다.

--- a/src/content/organizations/sakana-ai.md
+++ b/src/content/organizations/sakana-ai.md
@@ -1,0 +1,11 @@
+---
+orgId: "sakana-ai"
+name: "Sakana AI"
+status: "draft"
+updated: 2026-06-30
+sources:
+  - "https://sakana.ai/coffee-bench/"
+---
+
+# Sakana AI
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-06-30-profile-benchmark-sakana-ai.md
+++ b/src/data/issues/2026-06-30-profile-benchmark-sakana-ai.md
@@ -1,0 +1,15 @@
+---
+created: 2026-06-30
+agent: "profile-benchmark"
+severity: "minor"
+target: "organizations/sakana-ai"
+---
+
+## 상황
+CoffeeBench 벤치마크 페이지 작성 중 Sakana AI 기관 페이지가 누락되어 기본 스텁(stub)만 생성됨.
+
+## 시도한 것
+- src/content/organizations/sakana-ai.md 스텁 파일 생성 및 기본 연결 완료.
+
+## 요청
+Sakana AI (sakana-ai) 기관에 대한 구체적인 내용 조사 및 상세 프로필(설립일, 웹사이트 등) 작성 보강 요망.

--- a/src/data/journal/2026-06-30-profile-benchmark.md
+++ b/src/data/journal/2026-06-30-profile-benchmark.md
@@ -1,0 +1,22 @@
+---
+date: 2026-06-30
+agent: profile-benchmark
+status: completed
+summary: "CoffeeBench 프로필 및 Sakana AI 기관 스텁 생성"
+---
+
+## Todo
+- 등록이 필요한 신규 벤치마크 상세 페이지 작성
+
+## 조사 내역
+- 02:54 `coffeebench` 대상 선정 후 공식 페이지 (https://sakana.ai/coffee-bench/) 페치 및 내용 확인
+
+## 수행한 작업
+- [x] `src/content/benchmarks/coffeebench.md` 프로필 생성 ← https://sakana.ai/coffee-bench/
+- [x] `src/content/organizations/sakana-ai.md` 스텁 생성 및 연결 ← https://sakana.ai/coffee-bench/
+
+## 판단 / 고민
+- CoffeeBench와 관련하여 제작 기관인 Sakana AI 스텁도 함께 만들었으며, 기관 상세 내용을 채우기 위해 이슈 티켓을 함께 생성함.
+
+## 이슈 제기
+- issues/2026-06-30-profile-benchmark-sakana-ai.md


### PR DESCRIPTION
- Added `src/content/benchmarks/coffeebench.md` benchmark profile based on official sakana.ai source.
- Added `src/content/organizations/sakana-ai.md` organization stub.
- Created minor issue ticket `src/data/issues/2026-06-30-profile-benchmark-sakana-ai.md` for organization profiling.
- Created daily journal entry for `profile-benchmark` run on 2026-06-30 UTC.

---
*PR created automatically by Jules for task [4209388263264732926](https://jules.google.com/task/4209388263264732926) started by @GGJJack*