### PR TITLE
Profile benchmarks: AIME 2026 and MMMU Pro

### DIFF
--- a/src/content/benchmarks/aime-2026.md
+++ b/src/content/benchmarks/aime-2026.md
@@ -1,16 +1,20 @@
 ---
 benchmarkId: aime-2026
 domain: llm
-status: draft
-updated: 2026-06-12
+status: published
+updated: 2026-07-01
+organization: "matharena"
 sources:
   - https://huggingface.co/datasets/MathArena/aime_2026
+highlights:
+  - "MathArena 리더보드 평가용"
+  - "AIME 2026 대회 문제 포함"
 ---
 
 # AIME 2026
 
 ## 개요
-AIME 2026 수학 경시대회 문제입니다.
+MathArena 리더보드에서 사용되는 AIME 2026 문제들을 포함하는 데이터셋입니다. 30개의 문제와 정답이 포함되어 있습니다.
 
 ## 평가 방법
 평가 단위는 %를 사용합니다.

--- a/src/content/benchmarks/mmmu-pro.md
+++ b/src/content/benchmarks/mmmu-pro.md
@@ -1,16 +1,20 @@
 ---
 benchmarkId: mmmu-pro
 domain: llm
-status: draft
-updated: 2026-06-13
+status: published
+updated: 2026-07-01
+organization: "mmmu-team"
 sources:
   - https://mmmu-benchmark.github.io/
+highlights:
+  - "텍스트 전용 모델로 해결 가능한 문제 필터링"
+  - "질문을 이미지 내에 포함하여 평가"
 ---
 
 # MMMU Pro
 
 ## 개요
-멀티모달 능력을 평가하는 MMMU의 더 어려운 확장 버전입니다.
+MMMU 벤치마크의 더 강력한 버전으로, 텍스트만으로 풀 수 있는 문제를 필터링하고 후보 선택지를 늘렸으며, 질문을 이미지 내에 포함시켜 시각적, 텍스트적 정보를 통합하는 인지 능력을 평가합니다.
 
 ## 평가 방법
 평가 단위는 %를 사용합니다.

--- a/src/content/organizations/matharena.md
+++ b/src/content/organizations/matharena.md
@@ -1,0 +1,11 @@
+---
+orgId: matharena
+name: MathArena
+status: draft
+updated: 2026-07-01
+sources:
+  - https://matharena.ai/
+---
+
+# MathArena
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/content/organizations/mmmu-team.md
+++ b/src/content/organizations/mmmu-team.md
@@ -1,0 +1,11 @@
+---
+orgId: mmmu-team
+name: MMMU Team
+status: draft
+updated: 2026-07-01
+sources:
+  - https://mmmu-benchmark.github.io/
+---
+
+# MMMU Team
+<조직 개요 TBD. reinforce 가 보강 예정이거나 다음 사이클에 확장>

--- a/src/data/issues/2026-07-01-profile-benchmark-matharena.md
+++ b/src/data/issues/2026-07-01-profile-benchmark-matharena.md
@@ -1,0 +1,8 @@
+---
+created: 2026-07-01
+agent: profile-benchmark
+severity: minor
+target: organizations/matharena
+---
+
+기관 상세 조사 필요

--- a/src/data/issues/2026-07-01-profile-benchmark-mmmu-team.md
+++ b/src/data/issues/2026-07-01-profile-benchmark-mmmu-team.md
@@ -1,0 +1,8 @@
+---
+created: 2026-07-01
+agent: profile-benchmark
+severity: minor
+target: organizations/mmmu-team
+---
+
+기관 상세 조사 필요

--- a/src/data/journal/2026-07-01-profile-benchmark.md
+++ b/src/data/journal/2026-07-01-profile-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-07-01
+agent: profile-benchmark
+status: completed
+summary: "AIME 2026 및 MMMU Pro 벤치마크 상세 페이지 작성 및 기관 스텁 생성"
+---
+
+## Todo
+- [x] AIME 2026 벤치마크 상세 페이지 작성 및 `matharena` 기관 스텁 생성
+- [x] MMMU Pro 벤치마크 상세 페이지 작성 및 `mmmu-team` 기관 스텁 생성
+
+## 조사 내역
+- 02:30 AIME 2026 Hugging Face 데이터셋 페이지 확인 및 MathArena 리더보드와 연관성 확인 ← https://huggingface.co/datasets/MathArena/aime_2026
+- 02:35 MMMU Pro 공식 웹사이트 및 논문 초록 확인 (텍스트 문제 필터링, 이미지 질문 포함 등) ← https://mmmu-benchmark.github.io/ 및 https://arxiv.org/abs/2409.02813
+
+## 수행한 작업
+- [x] `src/content/benchmarks/aime-2026.md` 작성 완료 (status: published, organization: matharena)
+- [x] `src/content/organizations/matharena.md` 스텁 생성 및 이슈 생성
+- [x] `src/content/benchmarks/mmmu-pro.md` 작성 완료 (status: published, organization: mmmu-team)
+- [x] `src/content/organizations/mmmu-team.md` 스텁 생성 및 이슈 생성
+
+## 판단 / 고민
+- AIME 2026은 단독 기관이라기보다는 MathArena 리더보드 운영 주체의 데이터셋으로 등록된 것으로 보여 `matharena`로 기관 설정.
+- MMMU Pro는 다수 기관 협력 결과물로, 논문과 프로젝트 페이지에서 MMMU Team으로 명명되어 있어 `mmmu-team`으로 기관 설정.
+
+## 이슈 제기
+- issues/2026-07-01-profile-benchmark-matharena.md
+- issues/2026-07-01-profile-benchmark-mmmu-team.md


### PR DESCRIPTION
Updated profile pages for AIME 2026 and MMMU Pro benchmarks. Also created organization stubs for MathArena and MMMU Team, along with corresponding issues and a journal entry.

---
*PR created automatically by Jules for task [11027106295448449490](https://jules.google.com/task/11027106295448449490) started by @GGJJack*