### PR TITLE
Add profiles for DeepSeek-V4 Preview and Qwen-Turbo

### DIFF
--- a/src/content/models/deepseek-v4-preview.md
+++ b/src/content/models/deepseek-v4-preview.md
@@ -1,0 +1,33 @@
+---
+modelId: deepseek-v4-preview
+domain: llm
+status: published
+updated: 2026-07-02
+sources:
+  - https://api-docs.deepseek.com/zh-cn/news/news260424
+  - https://www.deepseek.com/
+  - https://api-docs.deepseek.com/zh-cn/quick_start/pricing
+features:
+  toolUse: true
+  vision: false
+  extendedThinking: true
+highlights:
+  - "DeepSeek-V4 시리즈의 프리뷰 버전으로 공개"
+  - "Agentic Coding 분야에서 Sonnet 4.5 이상의 사용자 경험 제공"
+  - "100만(1M) 토큰의 초장기 문맥과 DSA(DeepSeek Sparse Attention) 도입"
+relatedOrganization: deepseek
+---
+
+# DeepSeek-V4 Preview 소개
+
+## 개요
+DeepSeek-V4 Preview는 2026년 4월 24일 DeepSeek(深度求索)가 발표한 차세대 언어 모델 제품군의 초기 공개 버전입니다. 이 모델은 '백만 컨텍스트의 보편화 시대'를 선언하며, 모든 공식 서비스에 100만(1M) 토큰 컨텍스트를 기본 사양으로 도입했습니다. 오픈 소스 커뮤니티와 상업용 AI 시장 모두에서 최정상급 추론 성능과 에이전트 능력을 입증하며, 특히 소프트웨어 개발 에이전트 분야에서 독보적인 가성비와 성능을 보여주고 있습니다.
+
+## 기술 특징
+DeepSeek-V4 Preview는 기존의 어텐션 메커니즘을 혁신한 DSA(DeepSeek Sparse Attention)를 도입했습니다. 토큰 차원에서의 압축 기술과 희소 어텐션을 결합하여, 100만 토큰에 달하는 방대한 문맥을 처리할 때 발생하는 계산 리소스와 메모리 요구량을 획기적으로 줄였습니다. 또한, DeepSeek-V4-Pro와 DeepSeek-V4-Flash 두 가지 버전으로 나뉘어 제공되며, Pro 버전은 1.6조 개(1.6T)의 파라미터(활성 49B)를 가진 MoE 구조를 통해 세계 최고 수준의 수학 및 STEM 추론 성능을 구현했습니다. 특히 에이전틱 코딩(Agentic Coding) 벤치마크에서 기존 오픈 소스 모델 중 최고 수준을 기록했습니다.
+
+## 사용 사례
+DeepSeek-V4 Preview는 복잡한 다단계 워크플로우가 필요한 에이전트 환경에 최적화되어 있습니다. Claude Code, OpenClaw, CodeBuddy 등 주요 개발 에이전트 프레임워크와의 긴밀한 최적화를 통해 뛰어난 코드 생성 및 문서화 능력을 발휘합니다. 또한, 'Thinking Mode'를 통해 복잡한 수학 문제 해결이나 고난도 논리 추론 작업에서 심층적인 사고 과정을 수행할 수 있습니다. 1M 컨텍스트를 활용한 대규모 기술 문서 분석, 법률 검토, PPT 생성 자동화 등 지식 집약적인 비즈니스 시나리오에서 강력한 도구로 활용됩니다.
+
+## 한계
+프리뷰 버전인 만큼 일부 최고 난이도의 에이전트 작업에서는 OpenAI의 o1이나 Anthropic의 Opus 4.6(사고 모드) 대비 지능의 격차가 존재할 수 있음을 개발사측에서도 명시하고 있습니다. 또한, 텍스트와 코드의 논리적 구조 처리에 집중된 DSA 아키텍처 특성상 시각 자료나 음성 등 멀티모달 데이터를 직접 이해하는 기능은 포함되어 있지 않아, 해당 기능이 필요한 경우 별도의 특화 모델과의 연동이 필요합니다.

--- a/src/content/models/qwen-turbo.md
+++ b/src/content/models/qwen-turbo.md
@@ -1,0 +1,32 @@
+---
+modelId: qwen-turbo
+domain: llm
+status: published
+updated: 2026-07-02
+sources:
+  - https://qwenlm.github.io/blog/qwen2.5/
+  - https://qwenlm.github.io/blog/qwen2.5-llm/
+  - https://help.aliyun.com/zh/model-studio/developer-reference/what-is-qwen-llm
+features:
+  toolUse: true
+  vision: false
+highlights:
+  - "Qwen2.5 기반의 고성능 API 전용 모델"
+  - "GPT-4o-mini 수준의 성능을 제공하는 비용 효율적인 선택지"
+  - "128K 컨텍스트 지원 및 한국어 포함 29개 이상의 다국어 최적화"
+relatedOrganization: alibaba
+---
+
+# Qwen-Turbo 소개
+
+## 개요
+Qwen-Turbo는 Alibaba Cloud(阿里巴巴云)에서 제공하는 Qwen2.5 시리즈의 API 전용 언어 모델입니다. 대규모 서비스 환경에 적합하도록 처리 속도와 비용 효율성을 극대화한 것이 특징입니다. Qwen2.5-14B 및 32B 수준의 강력한 기반 지능을 갖추고 있으면서도, 빠른 응답 속도를 유지하여 실시간 챗봇, 요약, 번역 등 다양한 대화형 서비스에 최적화된 포지셔닝을 가지고 있습니다.
+
+## 기술 특징
+Qwen-Turbo는 Qwen2.5의 핵심 기술적 진보를 모두 포함하고 있습니다. 최대 128K 토큰의 긴 컨텍스트 윈도우를 지원하며, 8K 이상의 긴 텍스트 생성 능력을 갖추고 있습니다. 특히 구조화된 데이터 이해(표, 문서 구조 등) 및 JSON 형식의 정교한 출력이 가능하여 복잡한 시스템의 구성 요소로 활용하기에 적합합니다. 또한, 한국어를 포함한 29개 이상의 언어를 지원하며, 다양한 시스템 프롬프트에 대한 복원력(Resilience)이 강화되어 특정 역할이나 페르소나를 부여한 챗봇 구현 성능이 비약적으로 향상되었습니다.
+
+## 사용 사례
+이 모델은 성능과 비용의 균형이 중요한 상용화 단계의 서비스에 이상적입니다. GPT-4o-mini 등 타사의 경량형 API 모델과 경쟁 가능한 수준의 벤치마크 점수를 기록하고 있으며, 특히 수학(MATH) 및 코딩 영역에서 뛰어난 효율성을 보여줍니다. 실시간 고객 응대 시스템, 대규모 문서 대역폭 처리, 에이전트 기반의 자동화 툴 등에서 핵심 추론 엔진으로 널리 사용됩니다. Alibaba Cloud Model Studio를 통해 API 형태로 간편하게 연동할 수 있는 높은 접근성을 제공합니다.
+
+## 한계
+Qwen-Turbo는 속도와 비용에 최적화된 모델이므로, Qwen2.5-72B나 Qwen-Plus와 같은 최상위 플래그십 모델 대비 심층적인 논리 추론이나 방대한 지식 추출 능력에서는 다소 차이가 있을 수 있습니다. 또한 순수 텍스트 기반 모델로서 이미지나 오디오 데이터를 직접 입력받아 처리하는 멀티모달 기능은 제공하지 않으므로, 시각 정보 처리가 필요한 경우 Qwen2-VL 등 별도의 라인업을 함께 사용해야 합니다.

--- a/src/data/journal/2026-07-02-profile-model.md
+++ b/src/data/journal/2026-07-02-profile-model.md
@@ -1,0 +1,27 @@
+---
+date: 2026-07-02
+agent: profile-model
+status: in-progress
+summary: "DeepSeek-V4 Preview 및 Qwen-Turbo 상세 프로필 작성 시작"
+---
+
+## Todo
+- [ ] DeepSeek-V4 Preview 프로필 작성
+- [ ] Qwen-Turbo 프로필 작성
+
+## 조사 내역
+- 02:00 작업 시작 및 대상 모델 선정 (DeepSeek-V4 Preview, Qwen-Turbo)
+- 02:05 DeepSeek 공식 홈페이지 확인 (DeepSeek-V4 预览版本发布 확인)
+- 02:07 Qwen2.5 블로그 확인 (Qwen-Turbo 및 Qwen-Plus API 정보 확인)
+
+## 수행한 작업
+- [x] 대상 모델 레지스트리 확인 (deepseek-v4-preview, qwen-turbo)
+- [x] DeepSeek-V4 Preview 상세 프로필 작성 (src/content/models/deepseek-v4-preview.md)
+- [x] Qwen-Turbo 상세 프로필 작성 (src/content/models/qwen-turbo.md)
+
+## 판단 / 고민
+- DeepSeek-V4 Preview는 세계 최고 수준의 추론 성능과 에이전트 능력을 강조하고 있음.
+- Qwen-Turbo는 Qwen2.5 기반의 API 모델로, 비용 효율성과 빠른 속도를 강점으로 함.
+
+## 이슈 제기
+- (없음)

--- a/src/data/models/llm.json
+++ b/src/data/models/llm.json
@@ -1556,7 +1556,7 @@
       "id": "deepseek-v4-preview",
       "name": "DeepSeek-V4 Preview",
       "provider": "DeepSeek",
-      "releaseDate": "2026-05-18",
+      "releaseDate": "2026-04-24",
       "license": "DeepSeek Model License",
       "highlights": [
         "세계 최고 수준의 추론 성능",


### PR DESCRIPTION
Detailed profiles for DeepSeek-V4 Preview and Qwen-Turbo have been added to the project. These profiles include an overview, technical features, use cases, and limitations, all supported by official sources. The DeepSeek-V4 Preview entry in the LLM registry was also corrected to reflect the official release date.

Fixes #654

---
*PR created automatically by Jules for task [17013339251968535818](https://jules.google.com/task/17013339251968535818) started by @GGJJack*