### PR TITLE
Generate daily report and complete journal

### DIFF
--- a/src/data/journal/2026-07-03-journal.md
+++ b/src/data/journal/2026-07-03-journal.md
@@ -1,0 +1,16 @@
+---
+date: 2026-07-03
+agent: journal
+status: completed
+summary: "전일(2026-07-02) 에이전트 저널을 모아 데일리 리포트 발행 완료"
+---
+
+## Todo
+- [x] 전일(2026-07-02) 저널 모두 읽기
+- [x] 데일리 리포트 작성 (`src/data/updates/2026-07-02-daily.md`)
+- [x] 저널 상태 completed 로 변경
+
+## 수행한 작업
+- [x] `src/data/journal/2026-07-02-*.md` 파일 목록 확인 및 내용 추출 완료
+- [x] `src/data/updates/2026-07-02-daily.md` 파일 생성 및 내용 병합 완료
+- [x] `src/data/journal/2026-07-03-journal.md` (본인 저널) 생성 완료

--- a/src/data/updates/2026-07-02-daily.md
+++ b/src/data/updates/2026-07-02-daily.md
@@ -1,0 +1,24 @@
+---
+date: 2026-07-02
+type: note
+title: 데일리 리포트 · 2026-07-02
+summary: "전일(06-25 ~ 06-29) 신규/보강 등록된 LLM 모델 벤치마크 점수 매칭 시도 및 추가 등록 / DeepSeek-V4 Preview 및 Qwen-Turbo 상세 프로필 작성 시작 / Gemini Robotics-ER 1.6 벤치마크 및 주요 엔터프라이즈 모델 가격 정보 정기 점검 수행"
+---
+
+## 오늘의 수집
+
+### 벤치마크 (collect-benchmark)
+- [x] `solar-pro-3`: IFBench (55.78), Arena Hard v2 (62.5) 점수 추가 및 출처 기입. ← https://www.upstage.ai/blog/en/solar-pro-3-0127
+- [x] `sakana-fugu` 시리즈: 이미지 형태로만 점수가 제공되어 텍스트 미추출, 추가 등록 없음.
+- [x] `gpt-5-6` 프리뷰 시리즈 및 `gemini-3.5-flash-computer-use`: 벤치마크 미기재로 스킵.
+
+## 상세 페이지 작성 (profile)
+- [x] 대상 모델 레지스트리 확인 (deepseek-v4-preview, qwen-turbo)
+- [x] DeepSeek-V4 Preview 상세 프로필 작성 (src/content/models/deepseek-v4-preview.md)
+- [x] Qwen-Turbo 상세 프로필 작성 (src/content/models/qwen-turbo.md)
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 130건
+
+## 미해결 이슈
+- (없음)


### PR DESCRIPTION
Generated the daily report for 2026-07-02 and the journal for 2026-07-03 based on the `collect-benchmark`, `profile-model`, and `reinforce` journals from 2026-07-02. Verified build functionality after file generation.

---
*PR created automatically by Jules for task [7908766554371309907](https://jules.google.com/task/7908766554371309907) started by @GGJJack*