### PR TITLE
feat: Add flteval benchmark and leanstral-1-5 scores

### DIFF
--- a/src/data/benchmarks/llm.json
+++ b/src/data/benchmarks/llm.json
@@ -904,6 +904,25 @@
       "links": {
         "official": "https://sakana.ai/coffee-bench/"
       }
+    },
+    {
+      "id": "flteval",
+      "name": "FLTEval",
+      "nameKo": "FLTEval",
+      "category": "coding",
+      "description": "Formal Logic Theorem Evaluation",
+      "source": "https://github.com/mistralai/FLTEval",
+      "unit": "%",
+      "scoreRange": [
+        0,
+        100
+      ],
+      "higherIsBetter": true,
+      "metric": "pass@1",
+      "subMetrics": [
+        "pass@1",
+        "pass@8"
+      ]
     }
   ],
   "scores": {
@@ -3054,6 +3073,18 @@
         "source": "official",
         "sourceUrl": "https://mistral.ai/news/mistral-small-3-1/",
         "note": "Interpreted from GPQA-Diamond performance chart"
+      }
+    },
+    "leanstral-1-5": {
+      "flteval": {
+        "value": 28.9,
+        "date": "2026-07-03",
+        "source": "official",
+        "sourceUrl": "https://mistral.ai/news/leanstral-1-5/",
+        "subscores": {
+          "pass@1": 28.9,
+          "pass@8": 43.2
+        }
       }
     }
   }

--- a/src/data/issues/2026-07-04-collect-benchmark-missing-scores.md
+++ b/src/data/issues/2026-07-04-collect-benchmark-missing-scores.md
@@ -1,0 +1,17 @@
+---
+created: 2026-07-04
+agent: collect-benchmark
+severity: minor
+target: llm/claude-sonnet-5
+---
+
+## 상황
+Claude Sonnet 5 및 Gemini Omni Flash 의 발표 블로그 포스트에는 구체적인 벤치마크 수치(MMLU, GPQA 등)가 제공되지 않았거나 텍스트로 추출할 수 없는 형태로 제공됨.
+- https://www.anthropic.com/news/claude-sonnet-5
+- https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni-flash-nano-banana-2-lite/
+
+## 시도한 것
+공식 뉴스/발표 페이지(위 URL)에서 MMLU, HumanEval, MATH, GPQA 등 주요 벤치마크 키워드를 검색했으나, 명시적인 수치가 텍스트로 존재하지 않음을 확인.
+
+## 요청
+해당 모델들의 기술 보고서(Technical Report)나 공식 상세 문서가 공개되면 벤치마크 점수(llm 도메인)를 추가로 수집하여 등록할 것.

--- a/src/data/journal/2026-07-04-collect-benchmark.md
+++ b/src/data/journal/2026-07-04-collect-benchmark.md
@@ -1,0 +1,26 @@
+---
+date: 2026-07-04
+agent: collect-benchmark
+status: completed
+summary: "벤치마크 및 점수 조사"
+---
+
+## Todo
+- 등록된 벤치마크 리스트업 (llm 도메인)
+- 2026-07-04 collect-llm 저널 참고 (방금 실행된, 새 모델들)하여 해당 모델들 벤치마크 점수 추가
+- 발견되는 신규 벤치마크 등록
+
+## 조사 내역
+- 01:30  Claude Sonnet 5 벤치마크 점수 조사 (점수 미발견)  ← https://www.anthropic.com/news/claude-sonnet-5
+- 01:35  Leanstral 1.5 벤치마크 점수 조사 (FLTEval 발견)  ← https://mistral.ai/news/leanstral-1-5/
+- 01:40  Gemini Omni Flash 벤치마크 점수 조사 (상세 점수 미발견)  ← https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni-flash-nano-banana-2-lite/
+
+## 수행한 작업
+- [x] `flteval` (FLTEval) 신규 벤치마크 정의 등록  ← https://github.com/mistralai/FLTEval
+- [x] `leanstral-1-5` 의 `flteval` 점수 (28.9) 매칭 및 등록  ← https://mistral.ai/news/leanstral-1-5/
+
+## 판단 / 고민
+- Claude Sonnet 5 와 Gemini Omni Flash 의 발표 블로그/뉴스에는 상세한 벤치마크(MMLU, GPQA 등) 점수가 텍스트로 명시되어 있지 않아 등록을 보류함. (추가 기술 보고서나 공식 문서 등 다른 출처에서 확보 필요)
+
+## 이슈 제기
+- issues/2026-07-04-collect-benchmark-missing-scores.md


### PR DESCRIPTION
- Investigated 2026-07-04 new LLMs (Claude Sonnet 5, Gemini Omni Flash, Leanstral 1.5) for benchmark scores.
- Created an issue ticket for Claude Sonnet 5 and Gemini Omni Flash due to unextractable exact benchmark scores from their news release posts.
- Created `flteval` benchmark based on Leanstral 1.5 blog post findings.
- Successfully matched and added `flteval` benchmark scores (pass@1: 28.9, pass@8: 43.2) to the `leanstral-1-5` model.
- Wrote and updated the daily journal for the agent's work.

---
*PR created automatically by Jules for task [11075983192517506139](https://jules.google.com/task/11075983192517506139) started by @GGJJack*