### PR TITLE
docs: generate daily report for 2026-07-04

### DIFF
--- a/src/data/journal/2026-07-05-journal.md
+++ b/src/data/journal/2026-07-05-journal.md
@@ -1,0 +1,9 @@
+---
+date: 2026-07-05
+agent: journal
+status: completed
+summary: "Generated daily report for 2026-07-04"
+---
+
+## 수행한 작업
+- 2026-07-04 일자 데일리 리포트 생성 완료

--- a/src/data/updates/2026-07-04-daily.md
+++ b/src/data/updates/2026-07-04-daily.md
@@ -1,0 +1,26 @@
+---
+date: 2026-07-04
+type: note
+title: 데일리 리포트 · 2026-07-04
+summary: "신규 모델 및 벤치마크 데이터 수집, 프로필 작성 등 일일 자동화 작업 완료"
+---
+
+## 오늘의 수집
+
+### LLM (collect-llm)
+- [x] cross-discovery: `veo-3`, `veo-3-1` (image-gen) 신규 등록 ← https://deepmind.google/models/veo/
+- [x] `Claude Science` 및 `Co-Scientist` 조사: 조사 결과 독립 모델이 아닌 Anthropic 및 Google의 서비스/워크벤치 기능으로 판단되어 등록 제외 ← https://www.anthropic.com/news/claude-science-ai-workbench, https://deepmind.google
+- [x] `leanstral-1-5`: 파라미터(119B/6.5B), 컨텍스트(256k), 무료 API 가격 보강 ← https://docs.mistral.ai/models/model-cards/leanstral-1-5
+- [x] `gemini-omni-flash`: 텍스트 입출력 가격($1.5/$9) 보강 ← https://ai.google.dev/pricing
+- [x] `nano-banana-2-lite` (image-gen): 가격($0.0336 per 1K image) 재확인 ← https://ai.google.dev/pricing
+
+### 벤치마크 (collect-benchmark)
+- [x] `flteval` (FLTEval) 신규 벤치마크 정의 등록  ← https://github.com/mistralai/FLTEval
+- [x] `leanstral-1-5` 의 `flteval` 점수 (28.9) 매칭 및 등록  ← https://mistral.ai/news/leanstral-1-5/
+
+## 상세 페이지 작성 (profile)
+- [x] src/content/models/veo-3.md 신규 작성 (status: published)
+- [x] src/content/models/nano-banana-2-lite.md 신규 작성 (status: published)
+
+## 이슈 처리 (reinforce)
+- 해결 0건 / 부분 0건 / 잔여 132건


### PR DESCRIPTION
Generates the daily report for 2026-07-04 by parsing all relevant agent journal entries (collect-llm, collect-benchmark, profile-model, profile-benchmark) from yesterday. It aggregates the tasks performed, computes the remaining unresolved issues directly from the files in `src/data/issues/`, and publishes `src/data/updates/2026-07-04-daily.md`. It also creates its own log in `src/data/journal/2026-07-05-journal.md` marked as `status: completed` to wrap up the execution.

---
*PR created automatically by Jules for task [3243804526119784994](https://jules.google.com/task/3243804526119784994) started by @GGJJack*