### PR TITLE
chore: collect-benchmark daily run for 2026-07-05

### DIFF
--- a/src/data/journal/2026-07-05-collect-benchmark.md
+++ b/src/data/journal/2026-07-05-collect-benchmark.md
@@ -1,0 +1,28 @@
+---
+date: 2026-07-05
+agent: collect-benchmark
+status: completed
+summary: "Claude Sonnet 5, Gemini Omni Flash 벤치마크 점수 탐색 결과 없음, flteval 점수 중복 확인, 2026-07-05 모델 없음"
+---
+
+## Todo
+- 등록된 벤치마크 리스트업 (llm 도메인)
+- 오늘 신규 추가된 모델의 벤치마크 점수 추가
+- 2026-07-04 collect-llm 에 언급된 모델 중 미처리된 항목 재확인
+- 발견되는 신규 벤치마크 등록
+
+## 조사 내역
+- 01:30 Claude Sonnet 5 (https://www.anthropic.com/news/claude-sonnet-5) 추가 문서 탐색 하였으나 벤치마크 점수 미발견
+- 01:35 Gemini Omni Flash (https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-omni-flash-nano-banana-2-lite/) 탐색 하였으나 벤치마크 점수 미발견
+- 01:40 Veo 3 / Veo 3.1 은 image-gen 도메인이므로 패스
+
+## 수행한 작업
+- [x] llm 도메인 모델에 대한 새로운 벤치마크 점수가 없음을 확인
+
+## 판단 / 고민
+- 전일(2026-07-04) collect-llm 저널을 바탕으로 모델들의 벤치마크 점수를 탐색하였으나 명시된 점수가 없음.
+- 2026-07-05 collect-llm 저널은 아직 실행되지 않았음. (GH Actions 직후라고 되어 있으나 저널 파일 없음)
+- 따라서 벤치마크 점수를 추가할 내용이 없어, 상태를 completed 로 저장함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
Completed the daily run for `collect-benchmark` on 2026-07-05. Searched for new benchmark scores for models recently added, but no explicit new benchmark scores were found. Generated the daily journal with `status: completed`.

---
*PR created automatically by Jules for task [18360709598819255638](https://jules.google.com/task/18360709598819255638) started by @GGJJack*