### PR TITLE
collect-llm 2026-07-05 investigation

### DIFF
--- a/src/data/journal/2026-07-05-collect-llm.md
+++ b/src/data/journal/2026-07-05-collect-llm.md
@@ -1,0 +1,30 @@
+---
+date: 2026-07-05
+agent: collect-llm
+status: completed
+summary: "2026년 7월 1일~5일 기간 조사 결과, 신규 모델 출시 없음 및 기존 모델 메타데이터 현상 유지 확인"
+---
+
+## Todo
+- [x] 신규 모델 발견 및 등록 시도 (July 1-5, 2026)
+- [x] 기존 모델 보강 시도 (DeepSeek-V4, HCX-007, Sakana Marlin 등)
+- [x] 빌드 검증 및 제출
+
+## 조사 내역
+- 01:00  작업 시작 및 임무 확인 (GitHub Actions cron)
+- 01:10  공식 출처(OpenAI, Anthropic, Google, Mistral, Meta 등) 스캔
+- 01:20  HuggingFace 및 커뮤니티 리더보드 확인
+- 01:30  기존 모델(DeepSeek-V4-Pro, HCX-007, Sakana Marlin 등)의 최신 메타데이터(가격, 컨텍스트 윈도우) 재확인
+- 01:45  조사 결과: 7월 1일~5일 사이 신규 메이저 모델 출시 없음. 기존 모델의 비공개 메타데이터(기업용 가격 등) 역시 여전히 공식적으로 비공개 상태임.
+
+## 수행한 작업
+- [x] `llm` 도메인 전수 조사: 신규 모델 발견 실패 (신규 등록 건수: 0)
+- [x] 기존 모델 보강 시도: `deepseek-v4-preview`, `hcx-007`, `exaone-4-5-33b`, `sakana-marlin` 등 조사했으나 공식 스펙 업데이트 없음 (보강 건수: 0)
+- [x] 데이터 정합성 확인: `bun run skills/manage-model/scripts/model.ts list llm`으로 레지스트리 상태 확인 완료
+
+## 판단 / 고민
+- 무리한 데이터 추가보다 **출처 품질**과 **정확성**을 우선하여, 확인되지 않은 정보는 `null`로 유지함.
+- `leanstral-1-5`(7월 2일 출시)는 이미 이전 세션(7월 4일)에서 등록 및 보강이 완료된 것을 확인하여 중복 작업을 피함.
+
+## 이슈 제기
+- (없음)


### PR DESCRIPTION
This submission documents the scheduled LLM collection task for July 5, 2026. I investigated potential new model releases and metadata updates for the period of July 1-5, 2026. 

Key activities:
1. Scanned official blogs and release channels for OpenAI, Anthropic, Google, Meta, Mistral, and regional providers.
2. Verified that 'leanstral-1-5' (released July 2) was already registered.
3. Confirmed that no other major LLM models were released during this period.
4. Attempted to find pricing and technical specs for several models with null fields (DeepSeek-V4, HCX-007, Sakana Marlin, etc.), confirming they remain unavailable.
5. Recorded the full audit trail in `src/data/journal/2026-07-05-collect-llm.md`.
6. Verified registry integrity and build stability.

Fixes #678

---
*PR created automatically by Jules for task [18190665640654038992](https://jules.google.com/task/18190665640654038992) started by @GGJJack*